### PR TITLE
various fix and some coding style change

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -1,17 +1,17 @@
 #!/bin/sh
 
 error () {
-    echo -e "\033[31m[-] Error: $1\033[0m"
+    printf "\033[31m[-] Error: $1\033[0m\n"
     exit 1
 }
 
 success () {
-    echo -e "\033[32m[+] $1\033[0m"
+    printf "\033[32m[+] $1\033[0m\n"
     exit 0
 }
 
 info () {
-    echo -e "\033[36m[*] $1\033[0m"
+    printf "\033[36m[*] $1\033[0m\n"
 }
 
 logfile=/tmp/exeloader.build.log

--- a/include/ExeLoader.h
+++ b/include/ExeLoader.h
@@ -12,7 +12,5 @@ typedef int (*mainFunc2)(int argc, char* argv[]);
 typedef void (*FUNC_Version)(int _nMajor, int _nMinor);
 
 extern "C" bool fStartExeLoader(const char* Source_File);
-HMEMORYMODULE fMainExeLoader(const char* _sPath = "");
-void fix_relocations(IMAGE_BASE_RELOCATION *base_reloc, DWORD dir_size, DWORD new_imgbase, DWORD old_imgbase);
 
 #endif /* !EXELOADER_H */

--- a/include/ExeLoader.h
+++ b/include/ExeLoader.h
@@ -1,0 +1,18 @@
+#ifndef EXELOADER_H
+# define EXELOADER_H 1
+
+#define Func(_func) (void*)(&_func)
+#define DEREF_32(name) *(DWORD *)(name)
+#define BLOCKSIZE 100
+
+typedef int (*addNumberProc)(int, int);
+typedef void (*testFunc)();
+typedef int (*mainFunc)();
+typedef int (*mainFunc2)(int argc, char* argv[]);
+typedef void (*FUNC_Version)(int _nMajor, int _nMinor);
+
+extern "C" bool fStartExeLoader(const char* Source_File);
+HMEMORYMODULE fMainExeLoader(const char* _sPath = "");
+void fix_relocations(IMAGE_BASE_RELOCATION *base_reloc, DWORD dir_size, DWORD new_imgbase, DWORD old_imgbase);
+
+#endif /* !EXELOADER_H */

--- a/src/ExeLoader.cpp
+++ b/src/ExeLoader.cpp
@@ -149,7 +149,6 @@ long nExeFileSize;
     }
 #else /* !!! No Cpcdos !!! */
 
-<<<<<<< HEAD
 	//   #define UNICODE
 	//   #define _UNICODE
 	//    #include <windows.h>
@@ -233,87 +232,6 @@ long nExeFileSize;
 		fclose(f);
 		return false;
 	}
-=======
-    //   #define UNICODE
-    //   #define _UNICODE
-    //    #include <windows.h>
-
-    void _EXE_LOADER_DEBUG(int alert, const char* format_FR, const char* format_EN, ...) {
-        // Cette fonction permet d'utiliser le simuler un sprintf()
-        va_list arg;
-        char BUFFER[1024] = {0};
-
-        // TODO: Faire une condition si l'instance est en Francais ou non
-
-        va_start(arg, format_EN);
-            vsprintf(BUFFER, format_EN, arg);
-        va_end(arg);
-
-        printf("%s\n" , BUFFER);
-
-        // BUFFER[0] = '\0';
-        // printf("\n%d: %s",alert, format_FR);
-    }
-
-    /*
-    DWORD WINAPI GetModuleFileName(
-    _In_opt_ HMODULE hModule,
-    _Out_    char*  lpFilename,
-    _In_     DWORD   nSize
-    );
-    */
-    // #define MAX_PATH 255
-    gzBool fExeCpcDosLoadFile(const char* _sFullPath) {
-        if (_sFullPath == 0) {
-            printf("\n Error: No file to load. \n ");
-            return false;
-        }
-
-        // char buffer[MAX_PATH];
-        // GetModuleFileName(0, (char*)buffer, MAX_PATH );
-
-        //  gzUTF16 _wcFile(gzStrC(_sFullPath));
-        //   FILE*  f = _wfopen((wchar_t*)(gzUInt16*)_wcFile, L"rb+");
-        FILE*  f = fopen((char*)(gzUInt8*)_sFullPath, "rb+");
-        unsigned char *result;
-
-        if (f != NULL) {
-            WIN32_FILE_ATTRIBUTE_DATA fa;
-            /*
-            if (!GetFileAttributesExW((LPCWSTR)(gzUInt16*)_wcFile, GetFileExInfoStandard, &fa)){
-            // error handling
-            }*/
-            /*
-            if (!GetFileAttributesEx((LPCSTR)(gzUInt8*)_sFullPath, GetFileExInfoStandard, &fa)){
-            // error handling
-            }*/
-            //  int  size = ftell(f);
-            // obtain file size:
-
-            long lSize;
-            fseek(f , 0 , SEEK_END);
-            lSize = ftell(f);
-            rewind(f);
-            // gzUIntX _nSize =   ((gzUInt64)fa.nFileSizeHigh << 32) | fa.nFileSizeLow;
-            gzUIntX _nSize = lSize;
-
-            gzUInt8* _aData = new gzUInt8[_nSize];
-            fread(_aData, 1, _nSize, f);
-
-            nExeFileSize = _nSize;
-            aExeFileData = (char*)_aData;
-
-            // _oRc->fSetDynamicMemData(_aData, _nSize); //Will be auto free
-            // Lib_GZ::Sys::pDebug::fConsole(gzStrL("---File Open!-- ") + _sFullPath);
-            fclose(f);
-            return true;
-        } else {
-            // Lib_GZ::Sys::pDebug::fConsole(gzStrL("Error, can't open file : ") + _sFullPath);
-        }
-        fclose(f);
-        return false;
-    }
->>>>>>> ExeLoader.cpp: remove useless comment and move define,prototype,typedef in ExeLoader.h
 #endif /* !!! No Cpcdos !!! */
 
 bool fStartExeLoader(const char* _sPath) {

--- a/src/ExeLoader.cpp
+++ b/src/ExeLoader.cpp
@@ -107,68 +107,68 @@ long nExeFileSize;
 #ifdef CpcDos /* It's Cpcdos */
 
     gzSp<CpcdosOSx_CPintiCore> oCpc = gzSp<CpcdosOSx_CPintiCore>(new CpcdosOSx_CPintiCore);
-	
-	void _EXE_LOADER_DEBUG(int alert, const char* format_FR, const char* format_EN, ...)
-	{
-		// Cette fonction permet d'utiliser le simuler un sprintf()
-		va_list arg;
-		char BUFFER[1024] = {0};
-		
-		// Faire une condition si l'instance est en Francais ou non
-		
-		va_start (arg, format_EN);
-			vsprintf (BUFFER, format_FR, arg);
-		va_end (arg);
-		
-		oCpc->debug_log_plus((const char*) BUFFER, 1, 1, alert, 0, 0, 0,  1100, NULL); 	
-		
-		BUFFER[0] = '\0';
-	}
-	
+    
+    void _EXE_LOADER_DEBUG(int alert, const char* format_FR, const char* format_EN, ...)
+    {
+        // Cette fonction permet d'utiliser le simuler un sprintf()
+        va_list arg;
+        char BUFFER[1024] = {0};
+        
+        // Faire une condition si l'instance est en Francais ou non
+        
+        va_start (arg, format_EN);
+            vsprintf (BUFFER, format_FR, arg);
+        va_end (arg);
+        
+        oCpc->debug_log_plus((const char*) BUFFER, 1, 1, alert, 0, 0, 0,  1100, NULL); 	
+        
+        BUFFER[0] = '\0';
+    }
+    
 
 
     gzBool fExeCpcDosLoadFile(const char* _sFullPath)
-	{
+    {
 
-		nExeFileSize = 0;
-		aExeFileData = 0;
-		
-		_EXE_LOADER_DEBUG(0, "\nExeLoader: Test de l'existence de '%s'\n", "\nExeLoader: Test existence  '%s'\n", _sFullPath);
-		gzUInt _nExist = oCpc->File_exist((char*) _sFullPath);
-		if(_nExist > 0)
-		{
-			// Recuperer la taille du fichier
-			nExeFileSize =  oCpc->File_size((char*) _sFullPath);
-			
-			// Afficher sur la console Cpcdos
-			_EXE_LOADER_DEBUG(0, "ExeLoader: Lecture de %s (%d octets)...", "ExeLoader: Reading %s (%d bytes)...", _sFullPath, nExeFileSize);
-			
-			// Recuperer TOUT le contenu
-			aExeFileData = (char*) calloc(nExeFileSize + 1, sizeof(char));
-			
-			FILE *fptr;
+        nExeFileSize = 0;
+        aExeFileData = 0;
+        
+        _EXE_LOADER_DEBUG(0, "\nExeLoader: Test de l'existence de '%s'\n", "\nExeLoader: Test existence  '%s'\n", _sFullPath);
+        gzUInt _nExist = oCpc->File_exist((char*) _sFullPath);
+        if(_nExist > 0)
+        {
+            // Recuperer la taille du fichier
+            nExeFileSize =  oCpc->File_size((char*) _sFullPath);
+            
+            // Afficher sur la console Cpcdos
+            _EXE_LOADER_DEBUG(0, "ExeLoader: Lecture de %s (%d octets)...", "ExeLoader: Reading %s (%d bytes)...", _sFullPath, nExeFileSize);
+            
+            // Recuperer TOUT le contenu
+            aExeFileData = (char*) calloc(nExeFileSize + 1, sizeof(char));
+            
+            FILE *fptr;
 
-			if ((fptr = fopen(_sFullPath,"rb")) == NULL){
-				_EXE_LOADER_DEBUG(4, "\nExeLoader: Erreur d'ouverture du fichier %s.\n", "\nExeLoader: Error openning file %s.\n", _sFullPath);
-				return false;
-			}
-			
-			
-			fread(aExeFileData, nExeFileSize, 1, fptr);
-			
-			// oCpc->File_read_all((char*)_sFullPath, (char*)"RB", (char*)aExeFileData);
-			
-			// Caractere de terminaison
-			aExeFileData[nExeFileSize] = '\0';
-		}else{
-			  _EXE_LOADER_DEBUG(4, "\nExeLoader: Fichier non disponible %s.\n", "\nExeLoader: File not avaiable %s.\n", _sFullPath);
-			return false;
-		}
+            if ((fptr = fopen(_sFullPath,"rb")) == NULL){
+                _EXE_LOADER_DEBUG(4, "\nExeLoader: Erreur d'ouverture du fichier %s.\n", "\nExeLoader: Error openning file %s.\n", _sFullPath);
+                return false;
+            }
+            
+            
+            fread(aExeFileData, nExeFileSize, 1, fptr);
+            
+            // oCpc->File_read_all((char*)_sFullPath, (char*)"RB", (char*)aExeFileData);
+            
+            // Caractere de terminaison
+            aExeFileData[nExeFileSize] = '\0';
+        }else{
+              _EXE_LOADER_DEBUG(4, "\nExeLoader: Fichier non disponible %s.\n", "\nExeLoader: File not avaiable %s.\n", _sFullPath);
+            return false;
+        }
 
-		_EXE_LOADER_DEBUG(5, "ExeLoader: %s charge!", "ExeLoader:  %s loaded!\n" , _sFullPath);
+        _EXE_LOADER_DEBUG(5, "ExeLoader: %s charge!", "ExeLoader:  %s loaded!\n" , _sFullPath);
 
-		return true;
-	}
+        return true;
+    }
 #else /* !!! No Cpcdos !!! */
 
 	//   #define UNICODE
@@ -262,12 +262,12 @@ HMEMORYMODULE fMainExeLoader(const char* _sPath = "");
 
 
 bool fStartExeLoader(const char* _sPath){
-	if(fMainExeLoader(_sPath)==NULL){
-		return false;
-	}else{
-		return true;
-	}
-	//MemoryFreeLibrary(handle);
+    if(fMainExeLoader(_sPath)==NULL){
+        return false;
+    }else{
+        return true;
+    }
+    //MemoryFreeLibrary(handle);
 
 }
 

--- a/src/ExeLoader.cpp
+++ b/src/ExeLoader.cpp
@@ -259,7 +259,6 @@ long nExeFileSize;
 
 
 #include "MemoryModule.h"
-using namespace std;
 
 HMEMORYMODULE fMainExeLoader(const char* _sPath = "");
 
@@ -366,7 +365,7 @@ HMEMORYMODULE fMainExeLoader(const char* _sPath){
 	//#endif
 	
 	// Instancier MemoryModule
-	shared_ptr<MemoryModule> memory_module_instance(new MemoryModule());
+	std::shared_ptr<MemoryModule> memory_module_instance(new MemoryModule());
 
 	void *data;
 	long filesize;

--- a/src/ExeLoader.cpp
+++ b/src/ExeLoader.cpp
@@ -305,6 +305,7 @@ long nExeFileSize;
 
             // _oRc->fSetDynamicMemData(_aData, _nSize); //Will be auto free
             // Lib_GZ::Sys::pDebug::fConsole(gzStrL("---File Open!-- ") + _sFullPath);
+            fclose(f);
             return true;
         } else {
             // Lib_GZ::Sys::pDebug::fConsole(gzStrL("Error, can't open file : ") + _sFullPath);

--- a/src/ExeLoader.cpp
+++ b/src/ExeLoader.cpp
@@ -22,38 +22,35 @@
 #endif
 #include "MemoryModule.h"
 
-void signalHandler( int signum ) {
+void signalHandler(int signum) {
+    printf("\n Interrupt signal received: ");
 
-	
-   printf("\n Interrupt signal received: ");
+    // cleanup and close up stuff here
+    switch (signum) {
+    case SIGTERM:
+        printf("SIGTERM, termination request, sent to the program ");
+        break;
+    case SIGSEGV:
+        printf("SIGSEGV, invalid memory access (segmentation fault) ");
+        break;
+    case SIGINT:
+        printf("SIGINT, external interrupt, usually initiated by the user ");
+        break;
+    case SIGILL:
+        printf("SIGILL, invalid program image, such as invalid instruction ");
+        break;
+    case SIGABRT:
+        printf("SIGABRT, abnormal termination condition, as is e.g. initiated by std::abort()");
+        break;
+    case SIGFPE:
+        printf("SIGFPE, erroneous arithmetic operation such as divide by zero");
+        break;
+    default:
+        printf("UNKNOW");
+        break;
+    }
 
-   // cleanup and close up stuff here  
-   
-switch(signum){
-	case SIGTERM:
-		printf("SIGTERM, termination request, sent to the program ");
-	break;
-	case SIGSEGV:
-		printf("SIGSEGV, invalid memory access (segmentation fault) ");
-	break;
-	case SIGINT:
-		printf("SIGINT, external interrupt, usually initiated by the user ");
-	break;
-	case SIGILL:
-		printf("SIGILL, invalid program image, such as invalid instruction ");
-	break;
-	case SIGABRT:
-		printf("SIGABRT, abnormal termination condition, as is e.g. initiated by std::abort()");
-	break;
-	case SIGFPE:
-		printf("SIGFPE, erroneous arithmetic operation such as divide by zero");
-	break;
-	default:
-		printf("UNKNOW");
-	break;
-   }
-   
-   exit(signum);  
+    exit(signum);
 }
 
 /*
@@ -63,7 +60,7 @@ void segfault_sigaction(int signal, void* si, void *arg)
     exit(0);
 }*/
 
-void registerSignal(  ) {
+void registerSignal() {
 /* //No sigaction on Windows
 int *foo = NULL;
     struct sigaction sa;
@@ -73,9 +70,9 @@ int *foo = NULL;
     sa.sa_flags   = SA_SIGINFO;
     sigaction(SIGSEGV, NULL, NULL);
 */
-for(int i = 1; i < 32; i++){
-signal(i, signalHandler);
-}
+    for (int i = 1; i < 32; i++) {
+        signal(i, signalHandler);
+    }
 /*
 signal(SIGTERM, signalHandler);  //termination request, sent to the program
 signal(SIGSEGV, signalHandler);  //invalid memory access (segmentation fault)
@@ -86,7 +83,6 @@ signal(10, signalHandler); //SIGBUS
 */
 }
 ///////////////////////
- 
 
 extern "C" bool fStartExeLoader(const char* Source_File);
 
@@ -107,60 +103,53 @@ long nExeFileSize;
 #ifdef CpcDos /* It's Cpcdos */
 
     gzSp<CpcdosOSx_CPintiCore> oCpc = gzSp<CpcdosOSx_CPintiCore>(new CpcdosOSx_CPintiCore);
-    
-    void _EXE_LOADER_DEBUG(int alert, const char* format_FR, const char* format_EN, ...)
-    {
+
+    void _EXE_LOADER_DEBUG(int alert, const char* format_FR, const char* format_EN, ...) {
         // Cette fonction permet d'utiliser le simuler un sprintf()
         va_list arg;
         char BUFFER[1024] = {0};
-        
+
         // Faire une condition si l'instance est en Francais ou non
-        
-        va_start (arg, format_EN);
-            vsprintf (BUFFER, format_FR, arg);
-        va_end (arg);
-        
-        oCpc->debug_log_plus((const char*) BUFFER, 1, 1, alert, 0, 0, 0,  1100, NULL); 	
-        
+
+        va_start(arg, format_EN);
+            vsprintf(BUFFER, format_FR, arg);
+        va_end(arg);
+
+        oCpc->debug_log_plus((const char*) BUFFER, 1, 1, alert, 0, 0, 0,  1100, NULL);
+
         BUFFER[0] = '\0';
     }
-    
 
-
-    gzBool fExeCpcDosLoadFile(const char* _sFullPath)
-    {
-
+    gzBool fExeCpcDosLoadFile(const char* _sFullPath) {
         nExeFileSize = 0;
         aExeFileData = 0;
-        
+
         _EXE_LOADER_DEBUG(0, "\nExeLoader: Test de l'existence de '%s'\n", "\nExeLoader: Test existence  '%s'\n", _sFullPath);
         gzUInt _nExist = oCpc->File_exist((char*) _sFullPath);
-        if(_nExist > 0)
-        {
+        if (_nExist > 0) {
             // Recuperer la taille du fichier
             nExeFileSize =  oCpc->File_size((char*) _sFullPath);
-            
+
             // Afficher sur la console Cpcdos
             _EXE_LOADER_DEBUG(0, "ExeLoader: Lecture de %s (%d octets)...", "ExeLoader: Reading %s (%d bytes)...", _sFullPath, nExeFileSize);
-            
+
             // Recuperer TOUT le contenu
             aExeFileData = (char*) calloc(nExeFileSize + 1, sizeof(char));
-            
+
             FILE *fptr;
 
-            if ((fptr = fopen(_sFullPath,"rb")) == NULL){
+            if ((fptr = fopen(_sFullPath, "rb")) == NULL) {
                 _EXE_LOADER_DEBUG(4, "\nExeLoader: Erreur d'ouverture du fichier %s.\n", "\nExeLoader: Error openning file %s.\n", _sFullPath);
                 return false;
             }
-            
-            
+
             fread(aExeFileData, nExeFileSize, 1, fptr);
-            
+
             // oCpc->File_read_all((char*)_sFullPath, (char*)"RB", (char*)aExeFileData);
-            
+
             // Caractere de terminaison
             aExeFileData[nExeFileSize] = '\0';
-        }else{
+        } else {
               _EXE_LOADER_DEBUG(4, "\nExeLoader: Fichier non disponible %s.\n", "\nExeLoader: File not avaiable %s.\n", _sFullPath);
             return false;
         }
@@ -260,42 +249,34 @@ HMEMORYMODULE fMainExeLoader(const char* _sPath = "");
 
 #define Func(_func) (void*)(&_func)
 
-
-bool fStartExeLoader(const char* _sPath){
-    if(fMainExeLoader(_sPath)==NULL){
+bool fStartExeLoader(const char* _sPath) {
+    if (fMainExeLoader(_sPath) == NULL) {
         return false;
-    }else{
+    } else {
         return true;
     }
-    //MemoryFreeLibrary(handle);
-
+    // MemoryFreeLibrary(handle);
 }
-
 
 #ifdef ImWin
 int main(int argc, char* argv[]) {
-	printf("\nMain Called %d, %s", argc, argv[0]);
+    printf("#\nMainCalled!! %d, %s", argc, argv[0]);
 
-	fMainExeLoader(argv[1]); //argv[0] is path
-	// fMainExeLoader("App.exe"); //argv[0] is path
+    fMainExeLoader(argv[1]);  // argv[0] is path
+    printf("\n -- END -- \n");
+    system("Pause");
 
-
-	printf("\n -- END -- \n");
-	system("Pause");
-
-//MemoryFreeLibrary(handle);
+    // MemoryFreeLibrary(handle);
     return false;
 }
 #endif
 
-#define DEREF_32( name )*(DWORD *)(name)
+#define DEREF_32(name) *(DWORD *)(name)
 #define BLOCKSIZE 100
 
-void fix_relocations(IMAGE_BASE_RELOCATION *base_reloc,DWORD dir_size,	DWORD new_imgbase, DWORD old_imgbase);
-
+void fix_relocations(IMAGE_BASE_RELOCATION *base_reloc, DWORD dir_size, DWORD new_imgbase, DWORD old_imgbase);
 
 mainFunc2 fFindMainFunction(MemoryModule* _oMem, HMEMORYMODULE handle) {
-
 	mainFunc2 dMain ;
 	
 	
@@ -346,8 +327,6 @@ mainFunc2 fFindMainFunction(MemoryModule* _oMem, HMEMORYMODULE handle) {
 	
 	return NULL;
 }
-
-
 
 ////////////////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////////////////
@@ -466,6 +445,4 @@ HMEMORYMODULE fMainExeLoader(const char* _sPath){
 
 }
 
-
 //////////////////////////////// E N D  //////////////////////////////////////
-

--- a/src/ExeLoader.cpp
+++ b/src/ExeLoader.cpp
@@ -234,28 +234,6 @@ long nExeFileSize;
 	}
 #endif /* !!! No Cpcdos !!! */
 
-bool fStartExeLoader(const char* _sPath) {
-    if (fMainExeLoader(_sPath) == NULL) {
-        return false;
-    } else {
-        return true;
-    }
-    // MemoryFreeLibrary(handle);
-}
-
-#ifdef ImWin
-int main(int argc, char* argv[]) {
-    printf("#\nMainCalled!! %d, %s", argc, argv[0]);
-
-    fMainExeLoader(argv[1]);  // argv[0] is path
-    printf("\n -- END -- \n");
-    system("Pause");
-
-    // MemoryFreeLibrary(handle);
-    return false;
-}
-#endif
-
 mainFunc2 fFindMainFunction(MemoryModule* _oMem, HMEMORYMODULE handle) {
 	mainFunc2 dMain ;
 	
@@ -424,3 +402,25 @@ HMEMORYMODULE fMainExeLoader(const char* _sPath){
 	return handle;
 
 }
+
+bool fStartExeLoader(const char* _sPath) {
+    if (fMainExeLoader(_sPath) == NULL) {
+        return false;
+    } else {
+        return true;
+    }
+    // MemoryFreeLibrary(handle);
+}
+
+#ifdef ImWin
+int main(int argc, char* argv[]) {
+    printf("#\nMainCalled!! %d, %s", argc, argv[0]);
+
+    fMainExeLoader(argv[1]);  // argv[0] is path
+    printf("\n -- END -- \n");
+    system("Pause");
+
+    // MemoryFreeLibrary(handle);
+    return false;
+}
+#endif

--- a/src/ExeLoader.cpp
+++ b/src/ExeLoader.cpp
@@ -92,61 +92,69 @@ long nExeFileSize;
 #ifdef CpcDos /* It's Cpcdos */
 
     gzSp<CpcdosOSx_CPintiCore> oCpc = gzSp<CpcdosOSx_CPintiCore>(new CpcdosOSx_CPintiCore);
-
-    void _EXE_LOADER_DEBUG(int alert, const char* format_FR, const char* format_EN, ...) {
-        // Cette fonction permet d'utiliser le simuler un sprintf()
-        va_list arg;
-        char BUFFER[1024] = {0};
-
+	
+	void _EXE_LOADER_DEBUG(int alert, const char* format_FR, const char* format_EN, ...)
+	{
+		// Cette fonction permet d'utiliser le simuler un sprintf()
+		va_list arg;
+		char BUFFER[1024] = {0};
+		
+		// Faire une condition si l'instance est en Francais ou non
+		
+		va_start (arg, format_EN);
+			vsprintf (BUFFER, format_FR, arg);
+		va_end (arg);
+		
+		oCpc->debug_log_plus((const char*) BUFFER, 1, 1, alert, 0, 0, 0,  1100, NULL); 	
+		
+		BUFFER[0] = '\0';
+	}
+	
         // TODO: Faire une condition si l'instance est en Francais ou non
 
-        va_start(arg, format_EN);
-            vsprintf(BUFFER, format_FR, arg);
-        va_end(arg);
+    gzBool fExeCpcDosLoadFile(const char* _sFullPath)
+	{
 
-        oCpc->debug_log_plus((const char*) BUFFER, 1, 1, alert, 0, 0, 0,  1100, NULL);
+		nExeFileSize = 0;
+		aExeFileData = 0;
+		
+		_EXE_LOADER_DEBUG(0, "\nExeLoader: Test de l'existence de '%s'\n", "\nExeLoader: Test existence  '%s'\n", _sFullPath);
+		gzUInt _nExist = oCpc->File_exist((char*) _sFullPath);
+		if(_nExist > 0)
+		{
+			// Recuperer la taille du fichier
+			nExeFileSize =  oCpc->File_size((char*) _sFullPath);
+			
+			// Afficher sur la console Cpcdos
+			_EXE_LOADER_DEBUG(0, "ExeLoader: Lecture de %s (%d octets)...", "ExeLoader: Reading %s (%d bytes)...", _sFullPath, nExeFileSize);
+			
+			// Recuperer TOUT le contenu
+			aExeFileData = (char*) calloc(nExeFileSize + 1, sizeof(char));
+			
+			FILE *fptr;
 
-        BUFFER[0] = '\0';
-    }
+			if ((fptr = fopen(_sFullPath,"rb")) == NULL){
+				_EXE_LOADER_DEBUG(4, "\nExeLoader: Erreur d'ouverture du fichier %s.\n", "\nExeLoader: Error openning file %s.\n", _sFullPath);
+				return false;
+			}
+			
+			
+			fread(aExeFileData, nExeFileSize, 1, fptr);
+			
+			// oCpc->File_read_all((char*)_sFullPath, (char*)"RB", (char*)aExeFileData);
+			
+			// Caractere de terminaison
+			aExeFileData[nExeFileSize] = '\0';
+		} else {
+			_EXE_LOADER_DEBUG(4, "\nExeLoader: Fichier non disponible %s.\n", "\nExeLoader: File not avaiable %s.\n", _sFullPath);
+			return false;
+		}
 
-    gzBool fExeCpcDosLoadFile(const char* _sFullPath) {
-        nExeFileSize = 0;
-        aExeFileData = 0;
+		_EXE_LOADER_DEBUG(5, "ExeLoader: %s charge!", "ExeLoader:  %s loaded!\n" , _sFullPath);
 
-        _EXE_LOADER_DEBUG(0, "\nExeLoader: Test de l'existence de '%s'\n", "\nExeLoader: Test existence  '%s'\n", _sFullPath);
-        gzUInt _nExist = oCpc->File_exist((char*) _sFullPath);
-        if (_nExist > 0) {
-            // Recuperer la taille du fichier
-            nExeFileSize =  oCpc->File_size((char*) _sFullPath);
+		return true;
+	}
 
-            // Afficher sur la console Cpcdos
-            _EXE_LOADER_DEBUG(0, "ExeLoader: Lecture de %s (%d octets)...", "ExeLoader: Reading %s (%d bytes)...", _sFullPath, nExeFileSize);
-
-            // Recuperer TOUT le contenu
-            aExeFileData = (char*) calloc(nExeFileSize + 1, sizeof(char));
-
-            FILE *fptr;
-
-            if ((fptr = fopen(_sFullPath, "rb")) == NULL) {
-                _EXE_LOADER_DEBUG(4, "\nExeLoader: Erreur d'ouverture du fichier %s.\n", "\nExeLoader: Error openning file %s.\n", _sFullPath);
-                return false;
-            }
-
-            fread(aExeFileData, nExeFileSize, 1, fptr);
-
-            // oCpc->File_read_all((char*)_sFullPath, (char*)"RB", (char*)aExeFileData);
-
-            // Caractere de terminaison
-            aExeFileData[nExeFileSize] = '\0';
-        } else {
-              _EXE_LOADER_DEBUG(4, "\nExeLoader: Fichier non disponible %s.\n", "\nExeLoader: File not avaiable %s.\n", _sFullPath);
-            return false;
-        }
-
-        _EXE_LOADER_DEBUG(5, "ExeLoader: %s charge!", "ExeLoader:  %s loaded!\n" , _sFullPath);
-
-        return true;
-    }
 #else /* !!! No Cpcdos !!! */
 
 	//   #define UNICODE

--- a/src/ExeLoader.cpp
+++ b/src/ExeLoader.cpp
@@ -5,16 +5,22 @@
 // Update v3 10 OCT 2019
 // Update v4 30 JAN 2020
 // Update v5 12 MAR 2020
-  
-#include <memory>
-#include <iostream>
+
+#include <cstdlib>
 #include <cstdio>
 #include <cstring>
-#include <cstdarg> // Pour les arguments de fdebug_log
-#include <stdlib.h>
-
-//////////  Segfault catch //////////
+#include <cstdarg>  // Pour les arguments de fdebug_log
 #include <csignal>
+
+#include <memory>
+#include <iostream>
+
+#include "win.h"
+#include "Lib_GZ/GZ.h"
+#ifdef CpcDos
+    #include "Lib_GZ/SysUtils/CpcDosHeader.h"
+#endif
+#include "MemoryModule.h"
 
 void signalHandler( int signum ) {
 
@@ -95,16 +101,10 @@ typedef int (*mainFunc)();
 typedef int (*mainFunc2)(int argc, char* argv[]);
 typedef void (*FUNC_Version)(int _nMajor, int _nMinor);
 
-#include "Lib_GZ/GZ.h"
-
 char* aExeFileData;
 long nExeFileSize;
 
 #ifdef CpcDos /* It's Cpcdos */
-
-	#include "win.h"
-	
-    #include "Lib_GZ/SysUtils/CpcDosHeader.h"
 
     gzSp<CpcdosOSx_CPintiCore> oCpc = gzSp<CpcdosOSx_CPintiCore>(new CpcdosOSx_CPintiCore);
 	
@@ -174,7 +174,6 @@ long nExeFileSize;
 	//   #define UNICODE
 	//   #define _UNICODE
 	//    #include <windows.h>
-	#include "win.h"
 	
 	void _EXE_LOADER_DEBUG(int alert, const char* format_FR, const char* format_EN, ...)
 	{
@@ -256,9 +255,6 @@ long nExeFileSize;
 		return false;
 	}
 #endif /* !!! No Cpcdos !!! */
-
-
-#include "MemoryModule.h"
 
 HMEMORYMODULE fMainExeLoader(const char* _sPath = "");
 

--- a/src/ExeLoader.cpp
+++ b/src/ExeLoader.cpp
@@ -18,60 +18,60 @@
 #include "win.h"
 #include "Lib_GZ/GZ.h"
 #ifdef CpcDos
-    #include "Lib_GZ/SysUtils/CpcDosHeader.h"
+	#include "Lib_GZ/SysUtils/CpcDosHeader.h"
 #endif
 #include "MemoryModule.h"
 #include "ExeLoader.h"
 
 void signalHandler(int signum) {
-    printf("\n Interrupt signal received: ");
-    // cleanup and close up stuff here
-    switch (signum) {
-    case SIGTERM:
-        printf("SIGTERM, termination request, sent to the program ");
-        break;
-    case SIGSEGV:
-        printf("SIGSEGV, invalid memory access (segmentation fault) ");
-        break;
-    case SIGINT:
-        printf("SIGINT, external interrupt, usually initiated by the user ");
-        break;
-    case SIGILL:
-        printf("SIGILL, invalid program image, such as invalid instruction ");
-        break;
-    case SIGABRT:
-        printf("SIGABRT, abnormal termination condition, as is e.g. initiated by std::abort()");
-        break;
-    case SIGFPE:
-        printf("SIGFPE, erroneous arithmetic operation such as divide by zero");
-        break;
-    default:
-        printf("UNKNOW");
-        break;
-    }
-    exit(signum);
+	printf("\n Interrupt signal received: ");
+	// cleanup and close up stuff here
+	switch (signum) {
+	case SIGTERM:
+		printf("SIGTERM, termination request, sent to the program ");
+		break;
+	case SIGSEGV:
+		printf("SIGSEGV, invalid memory access (segmentation fault) ");
+		break;
+	case SIGINT:
+		printf("SIGINT, external interrupt, usually initiated by the user ");
+		break;
+	case SIGILL:
+		printf("SIGILL, invalid program image, such as invalid instruction ");
+		break;
+	case SIGABRT:
+		printf("SIGABRT, abnormal termination condition, as is e.g. initiated by std::abort()");
+		break;
+	case SIGFPE:
+		printf("SIGFPE, erroneous arithmetic operation such as divide by zero");
+		break;
+	default:
+		printf("UNKNOW");
+		break;
+	}
+	exit(signum);
 }
 
 /*
 void segfault_sigaction(int signal, void* si, void *arg)
 {
    printf("Caught segfault at address %p\n", si->si_addr);
-    exit(0);
+	exit(0);
 }*/
 
 void registerSignal() {
 /* //No sigaction on Windows
 int *foo = NULL;
-    struct sigaction sa;
-    memset(&sa, 0, sizeof(struct sigaction));
-    sigemptyset(&sa.sa_mask);
-    sa.sa_sigaction = segfault_sigaction;
-    sa.sa_flags   = SA_SIGINFO;
-    sigaction(SIGSEGV, NULL, NULL);
+	struct sigaction sa;
+	memset(&sa, 0, sizeof(struct sigaction));
+	sigemptyset(&sa.sa_mask);
+	sa.sa_sigaction = segfault_sigaction;
+	sa.sa_flags   = SA_SIGINFO;
+	sigaction(SIGSEGV, NULL, NULL);
 */
-    for (int i = 1; i < 32; i++) {
-        signal(i, signalHandler);
-    }
+	for (int i = 1; i < 32; i++) {
+		signal(i, signalHandler);
+	}
 /*
 signal(SIGTERM, signalHandler);  //termination request, sent to the program
 signal(SIGSEGV, signalHandler);  //invalid memory access (segmentation fault)
@@ -91,7 +91,7 @@ long nExeFileSize;
 
 #ifdef CpcDos /* It's Cpcdos */
 
-    gzSp<CpcdosOSx_CPintiCore> oCpc = gzSp<CpcdosOSx_CPintiCore>(new CpcdosOSx_CPintiCore);
+	gzSp<CpcdosOSx_CPintiCore> oCpc = gzSp<CpcdosOSx_CPintiCore>(new CpcdosOSx_CPintiCore);
 	
 	void _EXE_LOADER_DEBUG(int alert, const char* format_FR, const char* format_EN, ...)
 	{
@@ -110,9 +110,9 @@ long nExeFileSize;
 		BUFFER[0] = '\0';
 	}
 	
-        // TODO: Faire une condition si l'instance est en Francais ou non
+		// TODO: Faire une condition si l'instance est en Francais ou non
 
-    gzBool fExeCpcDosLoadFile(const char* _sFullPath)
+	gzBool fExeCpcDosLoadFile(const char* _sFullPath)
 	{
 
 		nExeFileSize = 0;
@@ -412,23 +412,23 @@ HMEMORYMODULE fMainExeLoader(const char* _sPath){
 }
 
 bool fStartExeLoader(const char* _sPath) {
-    if (fMainExeLoader(_sPath) == NULL) {
-        return false;
-    } else {
-        return true;
-    }
-    // MemoryFreeLibrary(handle);
+	if (fMainExeLoader(_sPath) == NULL) {
+		return false;
+	} else {
+		return true;
+	}
+	// MemoryFreeLibrary(handle);
 }
 
 #ifdef ImWin
 int main(int argc, char* argv[]) {
-    printf("#\nMainCalled!! %d, %s", argc, argv[0]);
+	printf("#\nMainCalled!! %d, %s", argc, argv[0]);
 
-    fMainExeLoader(argv[1]);  // argv[0] is path
-    printf("\n -- END -- \n");
-    system("Pause");
+	fMainExeLoader(argv[1]);  // argv[0] is path
+	printf("\n -- END -- \n");
+	system("Pause");
 
-    // MemoryFreeLibrary(handle);
-    return false;
+	// MemoryFreeLibrary(handle);
+	return false;
 }
 #endif

--- a/src/MemoryModule.cpp
+++ b/src/MemoryModule.cpp
@@ -404,9 +404,9 @@ BuildImportTable(PMEMORYMODULE module) {
             break;
         }
 
-        // tmp = (HCUSTOMMODULE *) realloc(module->modules, (module->numModules+1)*(sizeof(HCUSTOMMODULE)));
-        _EXE_LOADER_DEBUG(1, "\n Module No.%d de %d octets", "\n Module Nb.%d of %d bytes", (module->numModules+1), (module->numModules+1)*(sizeof(HCUSTOMMODULE)));
-
+       // tmp = (HCUSTOMMODULE *) realloc(module->modules, (module->numModules+1)*(sizeof(HCUSTOMMODULE)));
+       _EXE_LOADER_DEBUG(1, "\n Module No.%d de %d octets", "\n Module Nb.%d of %d bytes", (module->numModules+1), (module->numModules+1)*(sizeof(HCUSTOMMODULE)));
+	   
         tmp = (HCUSTOMMODULE *) malloc((module->numModules+1)*(sizeof(HCUSTOMMODULE)));
         if (tmp == 0) {
             module->freeLibrary(handle, module->userdata);
@@ -478,10 +478,10 @@ BuildImportTable(PMEMORYMODULE module) {
         _oModule->isDLL = true;
         _oModule->codeBase = (unsigned char*)filename;
 
-        // RECURSIVE!!
-        //   _oModule->modules = ( HCUSTOMMODULE *)fMainExeLoader(filename);
+        //RECURSIVE!!
+		//   _oModule->modules = ( HCUSTOMMODULE *)fMainExeLoader(filename);
 
-        //  return  fMainExeLoader(filename);
+		//  return  fMainExeLoader(filename);
 
         return (HCUSTOMMODULE*)_oModule;  // Temp, TODO
     }
@@ -601,7 +601,7 @@ HMEMORYMODULE MemoryModule::MemoryLoadLibraryEx(const void *data, size_t size,
     if (!CheckSize(size, sizeof(IMAGE_DOS_HEADER))) {
         return NULL;
     }
-
+	
     dos_header = (PIMAGE_DOS_HEADER)data;
     if (dos_header->e_magic != IMAGE_DOS_SIGNATURE) {
         SetLastError(ERROR_BAD_EXE_FORMAT);
@@ -909,7 +909,7 @@ HMEMORYRSRC MemoryModule::MemoryFindResource(HMEMORYMODULE module, LPCTSTR name,
 
 
 static PIMAGE_RESOURCE_DIRECTORY_ENTRY _MemorySearchResourceEntry(void *root, PIMAGE_RESOURCE_DIRECTORY resources,
-                                                                    LPCTSTR key) {
+		LPCTSTR key) {
     /* TODO: MemorySearchResourceEntry
 
     PIMAGE_RESOURCE_DIRECTORY_ENTRY entries = (PIMAGE_RESOURCE_DIRECTORY_ENTRY) (resources + 1);

--- a/src/MemoryModule.cpp
+++ b/src/MemoryModule.cpp
@@ -571,12 +571,6 @@ BuildImportTable(PMEMORYMODULE module) {
 
 #endif  // CustomLoader
 
-
-
-
-
-
-
 HMEMORYMODULE MemoryModule::MemoryLoadLibrary(const void *data, size_t size) {
     #ifdef CustomLoader
         return MemoryLoadLibraryEx(data, size, MyMemoryDefaultAlloc, MyMemoryDefaultFree, MyMemoryDefaultLoadLibrary, MyMemoryDefaultGetProcAddress, MyMemoryDefaultFreeLibrary, NULL);
@@ -769,11 +763,8 @@ HMEMORYMODULE MemoryModule::MemoryLoadLibraryEx(const void *data, size_t size,
     // get entry point of loaded library
     if (result->headers->OptionalHeader.AddressOfEntryPoint != 0) {
         if (result->isDLL) {
-<<<<<<< HEAD
                 // 
 			_EXE_LOADER_DEBUG(0, "Format de fichier : Librairie", "File format : Library");
-=======
->>>>>>> MemoryModule.cpp: add and remove space/blankline
             DllEntryProc DllEntry = (DllEntryProc)(LPVOID)(code + result->headers->OptionalHeader.AddressOfEntryPoint);
             if (DllEntry == 0) {
                 return NULL;
@@ -787,10 +778,7 @@ HMEMORYMODULE MemoryModule::MemoryLoadLibraryEx(const void *data, size_t size,
             */
             result->initialized = TRUE;
         } else {
-<<<<<<< HEAD
 			_EXE_LOADER_DEBUG(0, "Format de fichier : Executable Windows", "File format : Windows execuable");
-=======
->>>>>>> MemoryModule.cpp: add and remove space/blankline
             result->exeEntry = (ExeEntryProc)(LPVOID)(code + result->headers->OptionalHeader.AddressOfEntryPoint);
 			// fprintf(stdout, "Address 0x%08x\n", result->exeEntry);
         }

--- a/src/MemoryModule.cpp
+++ b/src/MemoryModule.cpp
@@ -425,7 +425,7 @@ BuildImportTable(PMEMORYMODULE module)
 
        // tmp = (HCUSTOMMODULE *) realloc(module->modules, (module->numModules+1)*(sizeof(HCUSTOMMODULE)));
        _EXE_LOADER_DEBUG(1, "\n Module No.%d de %d octets", "\n Module Nb.%d of %d bytes", (module->numModules+1), (module->numModules+1)*(sizeof(HCUSTOMMODULE)));
-	   
+       
         tmp = (HCUSTOMMODULE *) malloc((module->numModules+1)*(sizeof(HCUSTOMMODULE)));
         if (tmp == 0) {
             module->freeLibrary(handle, module->userdata);
@@ -504,9 +504,9 @@ BuildImportTable(PMEMORYMODULE module)
         _oModule->codeBase = (unsigned char*)filename;
 
         //RECURSIVE!!
-		//   _oModule->modules = ( HCUSTOMMODULE *)fMainExeLoader(filename);
+        //   _oModule->modules = ( HCUSTOMMODULE *)fMainExeLoader(filename);
 
-		//  return  fMainExeLoader(filename);
+        //  return  fMainExeLoader(filename);
 
         return (HCUSTOMMODULE*)_oModule; //Temp, TODO
 
@@ -651,7 +651,7 @@ HMEMORYMODULE MemoryModule::MemoryLoadLibraryEx(const void *data, size_t size,
     if (!CheckSize(size, sizeof(IMAGE_DOS_HEADER))) {
         return NULL;
     }
-	
+    
     dos_header = (PIMAGE_DOS_HEADER)data;
     if (dos_header->e_magic != IMAGE_DOS_SIGNATURE) {
         SetLastError(ERROR_BAD_EXE_FORMAT);
@@ -968,7 +968,7 @@ HMEMORYRSRC MemoryModule::MemoryFindResource(HMEMORYMODULE module, LPCTSTR name,
 
 
 static PIMAGE_RESOURCE_DIRECTORY_ENTRY _MemorySearchResourceEntry(void *root, PIMAGE_RESOURCE_DIRECTORY resources,
-																	LPCTSTR key)
+                                                                    LPCTSTR key)
 {
     /* TODO
 

--- a/src/MemoryModule.cpp
+++ b/src/MemoryModule.cpp
@@ -59,29 +59,29 @@ typedef BOOL (WINAPI *DllEntryProc)(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID 
 typedef int (WINAPI *ExeEntryProc)(void);
 
 typedef struct {
-    PIMAGE_NT_HEADERS headers;
-    unsigned char *codeBase;
-    HCUSTOMMODULE *modules;
-    int numModules;
-    BOOL initialized;
-    BOOL isDLL;
-    BOOL isRelocated;
-    CustomAllocFunc alloc;
-    CustomFreeFunc free;
-    CustomLoadLibraryFunc loadLibrary;
-    CustomGetProcAddressFunc getProcAddress;
-    CustomFreeLibraryFunc freeLibrary;
-    void *userdata;
-    ExeEntryProc exeEntry;
-    DWORD pageSize;
+	PIMAGE_NT_HEADERS headers;
+	unsigned char *codeBase;
+	HCUSTOMMODULE *modules;
+	int numModules;
+	BOOL initialized;
+	BOOL isDLL;
+	BOOL isRelocated;
+	CustomAllocFunc alloc;
+	CustomFreeFunc free;
+	CustomLoadLibraryFunc loadLibrary;
+	CustomGetProcAddressFunc getProcAddress;
+	CustomFreeLibraryFunc freeLibrary;
+	void *userdata;
+	ExeEntryProc exeEntry;
+	DWORD pageSize;
 } MEMORYMODULE, *PMEMORYMODULE;
 
 typedef struct {
-    LPVOID address;
-    LPVOID alignedAddress;
-    DWORD size;
-    DWORD characteristics;
-    BOOL last;
+	LPVOID address;
+	LPVOID alignedAddress;
+	DWORD size;
+	DWORD characteristics;
+	BOOL last;
 } SECTIONFINALIZEDATA, *PSECTIONFINALIZEDATA;
 
 #define GET_HEADER_DICTIONARY(module, idx)  &(module)->headers->OptionalHeader.DataDirectory[idx]
@@ -91,360 +91,360 @@ typedef struct {
 #ifdef DEBUG_OUTPUT
 static void
 OutputLastError(const char *msg) {
-    LPVOID tmp;
-    char *tmpmsg;
-    FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
-        NULL, GetLastError(), MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPTSTR)&tmp, 0, NULL);
-    tmpmsg = (char *)LocalAlloc(LPTR, strlen(msg) + strlen(tmp) + 3);
-    sprintf(tmpmsg, "%s: %s", msg, tmp);
-    OutputDebugString(tmpmsg);
-    LocalFree(tmpmsg);
-    LocalFree(tmp);
+	LPVOID tmp;
+	char *tmpmsg;
+	FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+		NULL, GetLastError(), MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPTSTR)&tmp, 0, NULL);
+	tmpmsg = (char *)LocalAlloc(LPTR, strlen(msg) + strlen(tmp) + 3);
+	sprintf(tmpmsg, "%s: %s", msg, tmp);
+	OutputDebugString(tmpmsg);
+	LocalFree(tmpmsg);
+	LocalFree(tmp);
 }
 #endif
 
 static BOOL
 CheckSize(size_t size, size_t expected) {
-    if (size < expected) {
-        SetLastError(ERROR_INVALID_DATA);
-        return FALSE;
-    }
-    return TRUE;
+	if (size < expected) {
+		SetLastError(ERROR_INVALID_DATA);
+		return FALSE;
+	}
+	return TRUE;
 }
 
 static BOOL
 CopySections(const unsigned char *data, size_t size, PIMAGE_NT_HEADERS old_headers, PMEMORYMODULE module) {
-    int i, section_size;
-    unsigned char *codeBase = module->codeBase;
-    unsigned char *dest;
-    PIMAGE_SECTION_HEADER section = IMAGE_FIRST_SECTION(module->headers);
-    for (i=0; i < module->headers->FileHeader.NumberOfSections; i++, section++) {
-        if (section->SizeOfRawData == 0) {
-            // section doesn't contain data in the dll itself, but may define
-            // uninitialized data
-            section_size = old_headers->OptionalHeader.SectionAlignment;
-            if (section_size > 0) {
-                dest = (unsigned char *)module->alloc(codeBase + section->VirtualAddress,
-                    section_size,
-                    MEM_COMMIT,
-                    PAGE_READWRITE,
-                    module->userdata);
-                if (dest == NULL) {
-                    return FALSE;
-                }
+	int i, section_size;
+	unsigned char *codeBase = module->codeBase;
+	unsigned char *dest;
+	PIMAGE_SECTION_HEADER section = IMAGE_FIRST_SECTION(module->headers);
+	for (i=0; i < module->headers->FileHeader.NumberOfSections; i++, section++) {
+		if (section->SizeOfRawData == 0) {
+			// section doesn't contain data in the dll itself, but may define
+			// uninitialized data
+			section_size = old_headers->OptionalHeader.SectionAlignment;
+			if (section_size > 0) {
+				dest = (unsigned char *)module->alloc(codeBase + section->VirtualAddress,
+					section_size,
+					MEM_COMMIT,
+					PAGE_READWRITE,
+					module->userdata);
+				if (dest == NULL) {
+					return FALSE;
+				}
 
-                // Always use position from file to support alignments smaller
-                // than page size.
-                dest = codeBase + section->VirtualAddress;
-                section->Misc.PhysicalAddress = (DWORD) (uintptr_t) dest;
-                memset(dest, 0, section_size);
-            }
+				// Always use position from file to support alignments smaller
+				// than page size.
+				dest = codeBase + section->VirtualAddress;
+				section->Misc.PhysicalAddress = (DWORD) (uintptr_t) dest;
+				memset(dest, 0, section_size);
+			}
 
-            // section is empty
-            continue;
-        }
+			// section is empty
+			continue;
+		}
 
-        if (!CheckSize(size, section->PointerToRawData + section->SizeOfRawData)) {
-            return FALSE;
-        }
+		if (!CheckSize(size, section->PointerToRawData + section->SizeOfRawData)) {
+			return FALSE;
+		}
 
-        // commit memory block and copy data from dll
-        dest = (unsigned char *)module->alloc(codeBase + section->VirtualAddress,
-                            section->SizeOfRawData,
-                            MEM_COMMIT,
-                            PAGE_READWRITE,
-                            module->userdata);
-        if (dest == NULL) {
-            return FALSE;
-        }
+		// commit memory block and copy data from dll
+		dest = (unsigned char *)module->alloc(codeBase + section->VirtualAddress,
+							section->SizeOfRawData,
+							MEM_COMMIT,
+							PAGE_READWRITE,
+							module->userdata);
+		if (dest == NULL) {
+			return FALSE;
+		}
 
-        // Always use position from file to support alignments smaller
-        // than page size.
-        dest = codeBase + section->VirtualAddress;
-        memcpy(dest, data + section->PointerToRawData, section->SizeOfRawData);
-        section->Misc.PhysicalAddress = (DWORD) (uintptr_t) dest;
-    }
-    return TRUE;
+		// Always use position from file to support alignments smaller
+		// than page size.
+		dest = codeBase + section->VirtualAddress;
+		memcpy(dest, data + section->PointerToRawData, section->SizeOfRawData);
+		section->Misc.PhysicalAddress = (DWORD) (uintptr_t) dest;
+	}
+	return TRUE;
 }
 
 // Protection flags for memory pages (Executable, Readable, Writeable)
 static int ProtectionFlags[2][2][2] = {
-    {
-        // not executable
-        {PAGE_NOACCESS, PAGE_WRITECOPY},
-        {PAGE_READONLY, PAGE_READWRITE},
-    }, {
-        // executable
-        {PAGE_EXECUTE, PAGE_EXECUTE_WRITECOPY},
-        {PAGE_EXECUTE_READ, PAGE_EXECUTE_READWRITE},
-    },
+	{
+		// not executable
+		{PAGE_NOACCESS, PAGE_WRITECOPY},
+		{PAGE_READONLY, PAGE_READWRITE},
+	}, {
+		// executable
+		{PAGE_EXECUTE, PAGE_EXECUTE_WRITECOPY},
+		{PAGE_EXECUTE_READ, PAGE_EXECUTE_READWRITE},
+	},
 };
 
 static DWORD
 GetRealSectionSize(PMEMORYMODULE module, PIMAGE_SECTION_HEADER section) {
-    DWORD size = section->SizeOfRawData;
-    if (size == 0) {
-        if (section->Characteristics & IMAGE_SCN_CNT_INITIALIZED_DATA) {
-            size = module->headers->OptionalHeader.SizeOfInitializedData;
-        } else if (section->Characteristics & IMAGE_SCN_CNT_UNINITIALIZED_DATA) {
-            size = module->headers->OptionalHeader.SizeOfUninitializedData;
-        }
-    }
-    return size;
+	DWORD size = section->SizeOfRawData;
+	if (size == 0) {
+		if (section->Characteristics & IMAGE_SCN_CNT_INITIALIZED_DATA) {
+			size = module->headers->OptionalHeader.SizeOfInitializedData;
+		} else if (section->Characteristics & IMAGE_SCN_CNT_UNINITIALIZED_DATA) {
+			size = module->headers->OptionalHeader.SizeOfUninitializedData;
+		}
+	}
+	return size;
 }
 
 static BOOL
 FinalizeSection(PMEMORYMODULE module, PSECTIONFINALIZEDATA sectionData) {
-    DWORD protect, oldProtect;
-    BOOL executable;
-    BOOL readable;
-    BOOL writeable;
+	DWORD protect, oldProtect;
+	BOOL executable;
+	BOOL readable;
+	BOOL writeable;
 
-    if (sectionData->size == 0) {
-        return TRUE;
-    }
+	if (sectionData->size == 0) {
+		return TRUE;
+	}
 
-    if (sectionData->characteristics & IMAGE_SCN_MEM_DISCARDABLE) {
-        // section is not needed any more and can safely be freed
-        if (sectionData->address == sectionData->alignedAddress &&
-            (sectionData->last ||
-             module->headers->OptionalHeader.SectionAlignment == module->pageSize ||
-             (sectionData->size % module->pageSize) == 0)
-           ) {
-            // Only allowed to decommit whole pages
-            module->free(sectionData->address, sectionData->size, MEM_DECOMMIT, module->userdata);
-        }
-        return TRUE;
-    }
+	if (sectionData->characteristics & IMAGE_SCN_MEM_DISCARDABLE) {
+		// section is not needed any more and can safely be freed
+		if (sectionData->address == sectionData->alignedAddress &&
+			(sectionData->last ||
+			 module->headers->OptionalHeader.SectionAlignment == module->pageSize ||
+			 (sectionData->size % module->pageSize) == 0)
+		   ) {
+			// Only allowed to decommit whole pages
+			module->free(sectionData->address, sectionData->size, MEM_DECOMMIT, module->userdata);
+		}
+		return TRUE;
+	}
 
-    // determine protection flags based on characteristics
-    executable = (sectionData->characteristics & IMAGE_SCN_MEM_EXECUTE) != 0;
-    readable =   (sectionData->characteristics & IMAGE_SCN_MEM_READ) != 0;
-    writeable =  (sectionData->characteristics & IMAGE_SCN_MEM_WRITE) != 0;
-    protect = ProtectionFlags[executable][readable][writeable];
-    if (sectionData->characteristics & IMAGE_SCN_MEM_NOT_CACHED) {
-        protect |= PAGE_NOCACHE;
-    }
+	// determine protection flags based on characteristics
+	executable = (sectionData->characteristics & IMAGE_SCN_MEM_EXECUTE) != 0;
+	readable =   (sectionData->characteristics & IMAGE_SCN_MEM_READ) != 0;
+	writeable =  (sectionData->characteristics & IMAGE_SCN_MEM_WRITE) != 0;
+	protect = ProtectionFlags[executable][readable][writeable];
+	if (sectionData->characteristics & IMAGE_SCN_MEM_NOT_CACHED) {
+		protect |= PAGE_NOCACHE;
+	}
 
-    #ifdef OnWin
-            // change memory access flags
-            if (VirtualProtect(sectionData->address, sectionData->size, protect, &oldProtect) == 0) {
-        #ifdef DEBUG_OUTPUT
-                OutputLastError("Error protecting memory page")
-        #endif
-                return FALSE;
-            }
-    #endif
+	#ifdef OnWin
+			// change memory access flags
+			if (VirtualProtect(sectionData->address, sectionData->size, protect, &oldProtect) == 0) {
+		#ifdef DEBUG_OUTPUT
+				OutputLastError("Error protecting memory page")
+		#endif
+				return FALSE;
+			}
+	#endif
 
-    return TRUE;
+	return TRUE;
 }
 
 static BOOL
 FinalizeSections(PMEMORYMODULE module) {
-    int i;
-    PIMAGE_SECTION_HEADER section = IMAGE_FIRST_SECTION(module->headers);
+	int i;
+	PIMAGE_SECTION_HEADER section = IMAGE_FIRST_SECTION(module->headers);
 #ifdef _WIN64
-    uintptr_t imageOffset = (module->headers->OptionalHeader.ImageBase & 0xffffffff00000000);
+	uintptr_t imageOffset = (module->headers->OptionalHeader.ImageBase & 0xffffffff00000000);
 #else
-    #define imageOffset 0
+	#define imageOffset 0
 #endif
-    SECTIONFINALIZEDATA sectionData;
-    sectionData.address = (LPVOID)((uintptr_t)section->Misc.PhysicalAddress | imageOffset);
-    sectionData.alignedAddress = ALIGN_DOWN(sectionData.address, module->pageSize);
-    sectionData.size = GetRealSectionSize(module, section);
-    sectionData.characteristics = section->Characteristics;
-    sectionData.last = FALSE;
-    section++;
+	SECTIONFINALIZEDATA sectionData;
+	sectionData.address = (LPVOID)((uintptr_t)section->Misc.PhysicalAddress | imageOffset);
+	sectionData.alignedAddress = ALIGN_DOWN(sectionData.address, module->pageSize);
+	sectionData.size = GetRealSectionSize(module, section);
+	sectionData.characteristics = section->Characteristics;
+	sectionData.last = FALSE;
+	section++;
 
-    // loop through all sections and change access flags
-    for (i=1; i < module->headers->FileHeader.NumberOfSections; i++, section++) {
-        LPVOID sectionAddress = (LPVOID)((uintptr_t)section->Misc.PhysicalAddress | imageOffset);
-        LPVOID alignedAddress = ALIGN_DOWN(sectionAddress, module->pageSize);
-        DWORD sectionSize = GetRealSectionSize(module, section);
-        // Combine access flags of all sections that share a page
-        // TODO(fancycode): We currently share flags of a trailing large section
-        //   with the page of a first small section. This should be optimized.
-        if (sectionData.alignedAddress == alignedAddress || (uintptr_t) sectionData.address + sectionData.size > (uintptr_t) alignedAddress) {
-            // Section shares page with previous
-            if ((section->Characteristics & IMAGE_SCN_MEM_DISCARDABLE) == 0 || (sectionData.characteristics & IMAGE_SCN_MEM_DISCARDABLE) == 0) {
-                sectionData.characteristics = (sectionData.characteristics | section->Characteristics) & ~IMAGE_SCN_MEM_DISCARDABLE;
-            } else {
-                sectionData.characteristics |= section->Characteristics;
-            }
-            sectionData.size = (((uintptr_t)sectionAddress) + sectionSize) - (uintptr_t) sectionData.address;
-            continue;
-        }
+	// loop through all sections and change access flags
+	for (i=1; i < module->headers->FileHeader.NumberOfSections; i++, section++) {
+		LPVOID sectionAddress = (LPVOID)((uintptr_t)section->Misc.PhysicalAddress | imageOffset);
+		LPVOID alignedAddress = ALIGN_DOWN(sectionAddress, module->pageSize);
+		DWORD sectionSize = GetRealSectionSize(module, section);
+		// Combine access flags of all sections that share a page
+		// TODO(fancycode): We currently share flags of a trailing large section
+		//   with the page of a first small section. This should be optimized.
+		if (sectionData.alignedAddress == alignedAddress || (uintptr_t) sectionData.address + sectionData.size > (uintptr_t) alignedAddress) {
+			// Section shares page with previous
+			if ((section->Characteristics & IMAGE_SCN_MEM_DISCARDABLE) == 0 || (sectionData.characteristics & IMAGE_SCN_MEM_DISCARDABLE) == 0) {
+				sectionData.characteristics = (sectionData.characteristics | section->Characteristics) & ~IMAGE_SCN_MEM_DISCARDABLE;
+			} else {
+				sectionData.characteristics |= section->Characteristics;
+			}
+			sectionData.size = (((uintptr_t)sectionAddress) + sectionSize) - (uintptr_t) sectionData.address;
+			continue;
+		}
 
-        if (!FinalizeSection(module, &sectionData)) {
-            return FALSE;
-        }
-        sectionData.address = sectionAddress;
-        sectionData.alignedAddress = alignedAddress;
-        sectionData.size = sectionSize;
-        sectionData.characteristics = section->Characteristics;
-    }
-    sectionData.last = TRUE;
-    if (!FinalizeSection(module, &sectionData)) {
-        return FALSE;
-    }
+		if (!FinalizeSection(module, &sectionData)) {
+			return FALSE;
+		}
+		sectionData.address = sectionAddress;
+		sectionData.alignedAddress = alignedAddress;
+		sectionData.size = sectionSize;
+		sectionData.characteristics = section->Characteristics;
+	}
+	sectionData.last = TRUE;
+	if (!FinalizeSection(module, &sectionData)) {
+		return FALSE;
+	}
 #ifndef _WIN64
 #undef imageOffset
 #endif
-    return TRUE;
+	return TRUE;
 }
 
 static BOOL
 ExecuteTLS(PMEMORYMODULE module) {
-    unsigned char *codeBase = module->codeBase;
-    PIMAGE_TLS_DIRECTORY tls;
-    PIMAGE_TLS_CALLBACK* callback;
+	unsigned char *codeBase = module->codeBase;
+	PIMAGE_TLS_DIRECTORY tls;
+	PIMAGE_TLS_CALLBACK* callback;
 
-    PIMAGE_DATA_DIRECTORY directory = GET_HEADER_DICTIONARY(module, IMAGE_DIRECTORY_ENTRY_TLS);
-    if (directory->VirtualAddress == 0) {
-        return TRUE;
-    }
+	PIMAGE_DATA_DIRECTORY directory = GET_HEADER_DICTIONARY(module, IMAGE_DIRECTORY_ENTRY_TLS);
+	if (directory->VirtualAddress == 0) {
+		return TRUE;
+	}
 
-    tls = (PIMAGE_TLS_DIRECTORY) (codeBase + directory->VirtualAddress);
-    callback = (PIMAGE_TLS_CALLBACK *) tls->AddressOfCallBacks;
-    if (callback) {
-        while (*callback) {
-            (*callback)((LPVOID) codeBase, DLL_PROCESS_ATTACH, NULL);
-            callback++;
-        }
-    }
-    return TRUE;
+	tls = (PIMAGE_TLS_DIRECTORY) (codeBase + directory->VirtualAddress);
+	callback = (PIMAGE_TLS_CALLBACK *) tls->AddressOfCallBacks;
+	if (callback) {
+		while (*callback) {
+			(*callback)((LPVOID) codeBase, DLL_PROCESS_ATTACH, NULL);
+			callback++;
+		}
+	}
+	return TRUE;
 }
 
 static BOOL
 PerformBaseRelocation(PMEMORYMODULE module, ptrdiff_t delta) {
-    unsigned char *codeBase = module->codeBase;
-    PIMAGE_BASE_RELOCATION relocation;
+	unsigned char *codeBase = module->codeBase;
+	PIMAGE_BASE_RELOCATION relocation;
 
-    PIMAGE_DATA_DIRECTORY directory = GET_HEADER_DICTIONARY(module, IMAGE_DIRECTORY_ENTRY_BASERELOC);
-    if (directory->Size == 0) {
-        return (delta == 0);
-    }
+	PIMAGE_DATA_DIRECTORY directory = GET_HEADER_DICTIONARY(module, IMAGE_DIRECTORY_ENTRY_BASERELOC);
+	if (directory->Size == 0) {
+		return (delta == 0);
+	}
 
-    relocation = (PIMAGE_BASE_RELOCATION) (codeBase + directory->VirtualAddress);
-    for (; relocation->VirtualAddress > 0; ) {
-        DWORD i;
-        unsigned char *dest = codeBase + relocation->VirtualAddress;
-        unsigned short *relInfo = (unsigned short *)((unsigned char *)relocation + IMAGE_SIZEOF_BASE_RELOCATION);
-        for (i=0; i < ((relocation->SizeOfBlock - IMAGE_SIZEOF_BASE_RELOCATION) / 2); i++, relInfo++) {
-            DWORD *patchAddrHL;
+	relocation = (PIMAGE_BASE_RELOCATION) (codeBase + directory->VirtualAddress);
+	for (; relocation->VirtualAddress > 0; ) {
+		DWORD i;
+		unsigned char *dest = codeBase + relocation->VirtualAddress;
+		unsigned short *relInfo = (unsigned short *)((unsigned char *)relocation + IMAGE_SIZEOF_BASE_RELOCATION);
+		for (i=0; i < ((relocation->SizeOfBlock - IMAGE_SIZEOF_BASE_RELOCATION) / 2); i++, relInfo++) {
+			DWORD *patchAddrHL;
 #ifdef _WIN64
-            ULONGLONG *patchAddr64;
+			ULONGLONG *patchAddr64;
 #endif
-            int type, offset;
+			int type, offset;
 
-            // the upper 4 bits define the type of relocation
-            type = *relInfo >> 12;
-            // the lower 12 bits define the offset
-            offset = *relInfo & 0xfff;
+			// the upper 4 bits define the type of relocation
+			type = *relInfo >> 12;
+			// the lower 12 bits define the offset
+			offset = *relInfo & 0xfff;
 
-            switch (type) {
-            case IMAGE_REL_BASED_ABSOLUTE:
-                // skip relocation
-                break;
+			switch (type) {
+			case IMAGE_REL_BASED_ABSOLUTE:
+				// skip relocation
+				break;
 
-            case IMAGE_REL_BASED_HIGHLOW:
-                // change complete 32 bit address
-                patchAddrHL = (DWORD *) (dest + offset);
-                *patchAddrHL += (DWORD) delta;
-                break;
+			case IMAGE_REL_BASED_HIGHLOW:
+				// change complete 32 bit address
+				patchAddrHL = (DWORD *) (dest + offset);
+				*patchAddrHL += (DWORD) delta;
+				break;
 
 #ifdef _WIN64
-            case IMAGE_REL_BASED_DIR64:
-                patchAddr64 = (ULONGLONG *) (dest + offset);
-                *patchAddr64 += (ULONGLONG) delta;
-                break;
+			case IMAGE_REL_BASED_DIR64:
+				patchAddr64 = (ULONGLONG *) (dest + offset);
+				*patchAddr64 += (ULONGLONG) delta;
+				break;
 #endif
 
-            default:
-                // printf("Unknown relocation: %d\n", type);
-                break;
-            }
-        }
+			default:
+				// printf("Unknown relocation: %d\n", type);
+				break;
+			}
+		}
 
-        // advance to next relocation block
-        relocation = (PIMAGE_BASE_RELOCATION) (((char *) relocation) + relocation->SizeOfBlock);
-    }
-    return TRUE;
+		// advance to next relocation block
+		relocation = (PIMAGE_BASE_RELOCATION) (((char *) relocation) + relocation->SizeOfBlock);
+	}
+	return TRUE;
 }
 
 static BOOL
 BuildImportTable(PMEMORYMODULE module) {
-    unsigned char *codeBase = module->codeBase;
-    PIMAGE_IMPORT_DESCRIPTOR importDesc;
-    BOOL result = TRUE;
+	unsigned char *codeBase = module->codeBase;
+	PIMAGE_IMPORT_DESCRIPTOR importDesc;
+	BOOL result = TRUE;
 
-    PIMAGE_DATA_DIRECTORY directory = GET_HEADER_DICTIONARY(module, IMAGE_DIRECTORY_ENTRY_IMPORT);
-    if (directory->Size == 0) {
-        return TRUE;
-    }
+	PIMAGE_DATA_DIRECTORY directory = GET_HEADER_DICTIONARY(module, IMAGE_DIRECTORY_ENTRY_IMPORT);
+	if (directory->Size == 0) {
+		return TRUE;
+	}
 
-    importDesc = (PIMAGE_IMPORT_DESCRIPTOR) (codeBase + directory->VirtualAddress);
+	importDesc = (PIMAGE_IMPORT_DESCRIPTOR) (codeBase + directory->VirtualAddress);
 
 
 #ifdef OnWin
-    for (; !IsBadReadPtr(importDesc, sizeof(IMAGE_IMPORT_DESCRIPTOR)) && importDesc->Name; importDesc++) {
+	for (; !IsBadReadPtr(importDesc, sizeof(IMAGE_IMPORT_DESCRIPTOR)) && importDesc->Name; importDesc++) {
 #else
-    for (; importDesc->Name; importDesc++) {
+	for (; importDesc->Name; importDesc++) {
 #endif
 
-        uintptr_t *thunkRef;
-        FARPROC *funcRef;
-        HCUSTOMMODULE *tmp;
+		uintptr_t *thunkRef;
+		FARPROC *funcRef;
+		HCUSTOMMODULE *tmp;
 
 
-        HCUSTOMMODULE handle = module->loadLibrary((LPCSTR) (codeBase + importDesc->Name), module->userdata);
-        if (handle == NULL) {
-            SetLastError(ERROR_MOD_NOT_FOUND);
-            result = FALSE;
-            break;
-        }
+		HCUSTOMMODULE handle = module->loadLibrary((LPCSTR) (codeBase + importDesc->Name), module->userdata);
+		if (handle == NULL) {
+			SetLastError(ERROR_MOD_NOT_FOUND);
+			result = FALSE;
+			break;
+		}
 
-       // tmp = (HCUSTOMMODULE *) realloc(module->modules, (module->numModules+1)*(sizeof(HCUSTOMMODULE)));
-       _EXE_LOADER_DEBUG(1, "\n Module No.%d de %d octets", "\n Module Nb.%d of %d bytes", (module->numModules+1), (module->numModules+1)*(sizeof(HCUSTOMMODULE)));
+	   // tmp = (HCUSTOMMODULE *) realloc(module->modules, (module->numModules+1)*(sizeof(HCUSTOMMODULE)));
+	   _EXE_LOADER_DEBUG(1, "\n Module No.%d de %d octets", "\n Module Nb.%d of %d bytes", (module->numModules+1), (module->numModules+1)*(sizeof(HCUSTOMMODULE)));
 	   
-        tmp = (HCUSTOMMODULE *) malloc((module->numModules+1)*(sizeof(HCUSTOMMODULE)));
-        if (tmp == 0) {
-            module->freeLibrary(handle, module->userdata);
-            SetLastError(ERROR_OUTOFMEMORY);
-            result = FALSE;
-            break;
-        }
-        module->modules = tmp;
+		tmp = (HCUSTOMMODULE *) malloc((module->numModules+1)*(sizeof(HCUSTOMMODULE)));
+		if (tmp == 0) {
+			module->freeLibrary(handle, module->userdata);
+			SetLastError(ERROR_OUTOFMEMORY);
+			result = FALSE;
+			break;
+		}
+		module->modules = tmp;
 
-        module->modules[module->numModules++] = handle;
-        if (importDesc->OriginalFirstThunk) {
-            thunkRef = (uintptr_t *) (codeBase + importDesc->OriginalFirstThunk);
-            funcRef = (FARPROC *) (codeBase + importDesc->FirstThunk);
-        } else {
-            // no hint table
-            thunkRef = (uintptr_t *) (codeBase + importDesc->FirstThunk);
-            funcRef = (FARPROC *) (codeBase + importDesc->FirstThunk);
-        }
-        for (; *thunkRef; thunkRef++, funcRef++) {
-            if (IMAGE_SNAP_BY_ORDINAL(*thunkRef)) {
-                *funcRef = module->getProcAddress(handle, (LPCSTR)IMAGE_ORDINAL(*thunkRef), module->userdata);
-            } else {
-                PIMAGE_IMPORT_BY_NAME thunkData = (PIMAGE_IMPORT_BY_NAME) (codeBase + (*thunkRef));
-                *funcRef = module->getProcAddress(handle, (LPCSTR)&thunkData->Name, module->userdata);
-            }
-            if (*funcRef == 0) {
-                result = FALSE;
-                break;
-            }
-        }
+		module->modules[module->numModules++] = handle;
+		if (importDesc->OriginalFirstThunk) {
+			thunkRef = (uintptr_t *) (codeBase + importDesc->OriginalFirstThunk);
+			funcRef = (FARPROC *) (codeBase + importDesc->FirstThunk);
+		} else {
+			// no hint table
+			thunkRef = (uintptr_t *) (codeBase + importDesc->FirstThunk);
+			funcRef = (FARPROC *) (codeBase + importDesc->FirstThunk);
+		}
+		for (; *thunkRef; thunkRef++, funcRef++) {
+			if (IMAGE_SNAP_BY_ORDINAL(*thunkRef)) {
+				*funcRef = module->getProcAddress(handle, (LPCSTR)IMAGE_ORDINAL(*thunkRef), module->userdata);
+			} else {
+				PIMAGE_IMPORT_BY_NAME thunkData = (PIMAGE_IMPORT_BY_NAME) (codeBase + (*thunkRef));
+				*funcRef = module->getProcAddress(handle, (LPCSTR)&thunkData->Name, module->userdata);
+			}
+			if (*funcRef == 0) {
+				result = FALSE;
+				break;
+			}
+		}
 
-        if (!result) {
-            module->freeLibrary(handle, module->userdata);
-            SetLastError(ERROR_PROC_NOT_FOUND);
-            break;
-        }
-    }
-    return result;
+		if (!result) {
+			module->freeLibrary(handle, module->userdata);
+			SetLastError(ERROR_PROC_NOT_FOUND);
+			break;
+		}
+	}
+	return result;
 }
 
 
@@ -452,683 +452,683 @@ BuildImportTable(PMEMORYMODULE module) {
 
 #ifdef CustomLoader
 
-    LPVOID MyMemoryDefaultAlloc(LPVOID address, SIZE_T size, DWORD allocationType, DWORD protect, void* userdata) {
-        UNREFERENCED_PARAMETER(userdata);
-        //  return VirtualAlloc(address, size, allocationType, protect);
-        return calloc(1, size);
-        // return malloc(size);
-    }
+	LPVOID MyMemoryDefaultAlloc(LPVOID address, SIZE_T size, DWORD allocationType, DWORD protect, void* userdata) {
+		UNREFERENCED_PARAMETER(userdata);
+		//  return VirtualAlloc(address, size, allocationType, protect);
+		return calloc(1, size);
+		// return malloc(size);
+	}
 
-    BOOL MyMemoryDefaultFree(LPVOID lpAddress, SIZE_T dwSize, DWORD dwFreeType, void* userdata) {
-        UNREFERENCED_PARAMETER(userdata);
-     //   return VirtualFree(lpAddress, dwSize, dwFreeType);
-        free(lpAddress);
-        return true;
-    }
+	BOOL MyMemoryDefaultFree(LPVOID lpAddress, SIZE_T dwSize, DWORD dwFreeType, void* userdata) {
+		UNREFERENCED_PARAMETER(userdata);
+	 //   return VirtualFree(lpAddress, dwSize, dwFreeType);
+		free(lpAddress);
+		return true;
+	}
 
-    HMEMORYMODULE fMainExeLoader(const char* _sPath);
+	HMEMORYMODULE fMainExeLoader(const char* _sPath);
 
-    HCUSTOMMODULE MyMemoryDefaultLoadLibrary(LPCSTR filename, void *userdata) {
-        HMODULE result;
-        UNREFERENCED_PARAMETER(userdata);
+	HCUSTOMMODULE MyMemoryDefaultLoadLibrary(LPCSTR filename, void *userdata) {
+		HMODULE result;
+		UNREFERENCED_PARAMETER(userdata);
 
-        _EXE_LOADER_DEBUG(1, "\n------ [DLL] Import:%s \n", "\n------ [DLL] Import:%s \n",   filename);
+		_EXE_LOADER_DEBUG(1, "\n------ [DLL] Import:%s \n", "\n------ [DLL] Import:%s \n",   filename);
 
-        MEMORYMODULE* _oModule =  (MEMORYMODULE*)calloc(1, sizeof(MEMORYMODULE));
-        _oModule->isDLL = true;
-        _oModule->codeBase = (unsigned char*)filename;
+		MEMORYMODULE* _oModule =  (MEMORYMODULE*)calloc(1, sizeof(MEMORYMODULE));
+		_oModule->isDLL = true;
+		_oModule->codeBase = (unsigned char*)filename;
 
-        //RECURSIVE!!
+		//RECURSIVE!!
 		//   _oModule->modules = ( HCUSTOMMODULE *)fMainExeLoader(filename);
 
 		//  return  fMainExeLoader(filename);
 
-        return (HCUSTOMMODULE*)_oModule;  // Temp, TODO
-    }
+		return (HCUSTOMMODULE*)_oModule;  // Temp, TODO
+	}
 
-    FARPROC MyMemoryDefaultGetProcAddress(HCUSTOMMODULE module, LPCSTR name, void *userdata) {
-        UNREFERENCED_PARAMETER(userdata);
+	FARPROC MyMemoryDefaultGetProcAddress(HCUSTOMMODULE module, LPCSTR name, void *userdata) {
+		UNREFERENCED_PARAMETER(userdata);
 
-        MEMORYMODULE* _oDll = (MEMORYMODULE*)module;
-        char* sDllName = (char*)"";
+		MEMORYMODULE* _oDll = (MEMORYMODULE*)module;
+		char* sDllName = (char*)"";
 
-        if (_oDll != 0) {
-           sDllName =  (char*)_oDll->codeBase;
-        }
+		if (_oDll != 0) {
+		   sDllName =  (char*)_oDll->codeBase;
+		}
 
-        unsigned int _nSize = sizeof(aTableFunc) /  sizeof(sFunc);
-        for (unsigned int i=0; i < _nSize; i++) {
-            if (strcmp(name, aTableFunc[i].sFuncName) == 0) {
-                            _EXE_LOADER_DEBUG(5, "Trouve %s: --> %s [CHARGE]", "Found %s: --> %s [LOADED]",  sDllName, name);
+		unsigned int _nSize = sizeof(aTableFunc) /  sizeof(sFunc);
+		for (unsigned int i=0; i < _nSize; i++) {
+			if (strcmp(name, aTableFunc[i].sFuncName) == 0) {
+							_EXE_LOADER_DEBUG(5, "Trouve %s: --> %s [CHARGE]", "Found %s: --> %s [LOADED]",  sDllName, name);
 
-                return (FARPROC)aTableFunc[i].dFunc;
-            }
-        }
+				return (FARPROC)aTableFunc[i].dFunc;
+			}
+		}
 
-        static unsigned int current = 0;
-        current++;
+		static unsigned int current = 0;
+		current++;
 
-        _EXE_LOADER_DEBUG(3, "\nAvertissement, %s:  ---------   %s ", "\nWarning, %s:  ---------   %s ",  sDllName, name);
+		_EXE_LOADER_DEBUG(3, "\nAvertissement, %s:  ---------   %s ", "\nWarning, %s:  ---------   %s ",  sDllName, name);
 
-        aDummyFunc[current].Who = name;
-        aDummyFunc[current].DLL = sDllName;
+		aDummyFunc[current].Who = name;
+		aDummyFunc[current].DLL = sDllName;
 
-        if (current >=  sizeof(aDummyFunc) / sizeof( aDummyFunc[0] )) {
-            current = 0;
-        }
+		if (current >=  sizeof(aDummyFunc) / sizeof( aDummyFunc[0] )) {
+			current = 0;
+		}
 
-      //  return 0;
-       return (FARPROC)aDummyFunc[current].dFunc;
-    }
+	  //  return 0;
+	   return (FARPROC)aDummyFunc[current].dFunc;
+	}
 
-    void MyMemoryDefaultFreeLibrary(HCUSTOMMODULE module, void *userdata) {
-        UNREFERENCED_PARAMETER(userdata);
-        // FreeLibrary((HMODULE) module);
-    }
+	void MyMemoryDefaultFreeLibrary(HCUSTOMMODULE module, void *userdata) {
+		UNREFERENCED_PARAMETER(userdata);
+		// FreeLibrary((HMODULE) module);
+	}
 
 ///////////////////////////////////////////////////////////////////////////
 
 #else  // Im on windows
 
-    LPVOID MemoryDefaultAlloc(LPVOID address, SIZE_T size, DWORD allocationType, DWORD protect, void* userdata) {
-        UNREFERENCED_PARAMETER(userdata);
-        return VirtualAlloc(address, size, allocationType, protect);
-    }
+	LPVOID MemoryDefaultAlloc(LPVOID address, SIZE_T size, DWORD allocationType, DWORD protect, void* userdata) {
+		UNREFERENCED_PARAMETER(userdata);
+		return VirtualAlloc(address, size, allocationType, protect);
+	}
 
-    BOOL MemoryDefaultFree(LPVOID lpAddress, SIZE_T dwSize, DWORD dwFreeType, void* userdata) {
-        UNREFERENCED_PARAMETER(userdata);
-        return VirtualFree(lpAddress, dwSize, dwFreeType);
-    }
+	BOOL MemoryDefaultFree(LPVOID lpAddress, SIZE_T dwSize, DWORD dwFreeType, void* userdata) {
+		UNREFERENCED_PARAMETER(userdata);
+		return VirtualFree(lpAddress, dwSize, dwFreeType);
+	}
 
-    HCUSTOMMODULE MemoryDefaultLoadLibrary(LPCSTR filename, void *userdata) {
-        HMODULE result;
-        UNREFERENCED_PARAMETER(userdata);
+	HCUSTOMMODULE MemoryDefaultLoadLibrary(LPCSTR filename, void *userdata) {
+		HMODULE result;
+		UNREFERENCED_PARAMETER(userdata);
 
-        _EXE_LOADER_DEBUG(1, "\n------ DLL:%s \n", "\n------ DLL:%s \n",   filename);
+		_EXE_LOADER_DEBUG(1, "\n------ DLL:%s \n", "\n------ DLL:%s \n",   filename);
 
-        result = LoadLibraryA(filename);
-        if (result == NULL) {
-            return NULL;
-        }
+		result = LoadLibraryA(filename);
+		if (result == NULL) {
+			return NULL;
+		}
 
-        return (HCUSTOMMODULE) result;
-    }
+		return (HCUSTOMMODULE) result;
+	}
 
-    FARPROC MemoryDefaultGetProcAddress(HCUSTOMMODULE module, LPCSTR name, void *userdata) {
-        UNREFERENCED_PARAMETER(userdata);
-            _EXE_LOADER_DEBUG(1, "Fonction: %s \n", "Function: %s \n",   name);
+	FARPROC MemoryDefaultGetProcAddress(HCUSTOMMODULE module, LPCSTR name, void *userdata) {
+		UNREFERENCED_PARAMETER(userdata);
+			_EXE_LOADER_DEBUG(1, "Fonction: %s \n", "Function: %s \n",   name);
 
-        return (FARPROC) GetProcAddress((HMODULE) module, name);
-    }
+		return (FARPROC) GetProcAddress((HMODULE) module, name);
+	}
 
-    void MemoryDefaultFreeLibrary(HCUSTOMMODULE module, void *userdata) {
-        UNREFERENCED_PARAMETER(userdata);
+	void MemoryDefaultFreeLibrary(HCUSTOMMODULE module, void *userdata) {
+		UNREFERENCED_PARAMETER(userdata);
 
-        FreeLibrary((HMODULE) module);
-    }
+		FreeLibrary((HMODULE) module);
+	}
 
 ///////////////////////////////////////////////////////////////////////////
 
 #endif  // CustomLoader
 
 HMEMORYMODULE MemoryModule::MemoryLoadLibrary(const void *data, size_t size) {
-    #ifdef CustomLoader
-        return MemoryLoadLibraryEx(data, size, MyMemoryDefaultAlloc, MyMemoryDefaultFree, MyMemoryDefaultLoadLibrary, MyMemoryDefaultGetProcAddress, MyMemoryDefaultFreeLibrary, NULL);
-    #else  // Windows standard
-        return MemoryLoadLibraryEx(data, size, MemoryDefaultAlloc, MemoryDefaultFree, MemoryDefaultLoadLibrary, MemoryDefaultGetProcAddress, MemoryDefaultFreeLibrary, NULL);
-    #endif
+	#ifdef CustomLoader
+		return MemoryLoadLibraryEx(data, size, MyMemoryDefaultAlloc, MyMemoryDefaultFree, MyMemoryDefaultLoadLibrary, MyMemoryDefaultGetProcAddress, MyMemoryDefaultFreeLibrary, NULL);
+	#else  // Windows standard
+		return MemoryLoadLibraryEx(data, size, MemoryDefaultAlloc, MemoryDefaultFree, MemoryDefaultLoadLibrary, MemoryDefaultGetProcAddress, MemoryDefaultFreeLibrary, NULL);
+	#endif
 }
 
 HMEMORYMODULE MemoryModule::MemoryLoadLibraryEx(const void *data, size_t size,
-    CustomAllocFunc allocMemory,
-    CustomFreeFunc freeMemory,
-    CustomLoadLibraryFunc loadLibrary,
-    CustomGetProcAddressFunc getProcAddress,
-    CustomFreeLibraryFunc freeLibrary,
-    void *userdata) {
-    PMEMORYMODULE result = NULL;
-    PIMAGE_DOS_HEADER dos_header;
-    PIMAGE_NT_HEADERS old_header;
-    unsigned char *code, *headers;
-    ptrdiff_t locationDelta;
-    SYSTEM_INFO sysInfo;
-    PIMAGE_SECTION_HEADER section;
-    DWORD i;
-    size_t optionalSectionSize;
-    size_t lastSectionEnd = 0;
-    size_t alignedImageSize;
+	CustomAllocFunc allocMemory,
+	CustomFreeFunc freeMemory,
+	CustomLoadLibraryFunc loadLibrary,
+	CustomGetProcAddressFunc getProcAddress,
+	CustomFreeLibraryFunc freeLibrary,
+	void *userdata) {
+	PMEMORYMODULE result = NULL;
+	PIMAGE_DOS_HEADER dos_header;
+	PIMAGE_NT_HEADERS old_header;
+	unsigned char *code, *headers;
+	ptrdiff_t locationDelta;
+	SYSTEM_INFO sysInfo;
+	PIMAGE_SECTION_HEADER section;
+	DWORD i;
+	size_t optionalSectionSize;
+	size_t lastSectionEnd = 0;
+	size_t alignedImageSize;
 
-    if (!CheckSize(size, sizeof(IMAGE_DOS_HEADER))) {
-        return NULL;
-    }
+	if (!CheckSize(size, sizeof(IMAGE_DOS_HEADER))) {
+		return NULL;
+	}
 	
-    dos_header = (PIMAGE_DOS_HEADER)data;
-    if (dos_header->e_magic != IMAGE_DOS_SIGNATURE) {
-        SetLastError(ERROR_BAD_EXE_FORMAT);
-        return NULL;
-    }
+	dos_header = (PIMAGE_DOS_HEADER)data;
+	if (dos_header->e_magic != IMAGE_DOS_SIGNATURE) {
+		SetLastError(ERROR_BAD_EXE_FORMAT);
+		return NULL;
+	}
 
 
-    if (!CheckSize(size, dos_header->e_lfanew + sizeof(IMAGE_NT_HEADERS))) {
-        return NULL;
-    }
-    old_header = (PIMAGE_NT_HEADERS)&((const unsigned char *)(data))[dos_header->e_lfanew];
-    if (old_header->Signature != IMAGE_NT_SIGNATURE) {
-        SetLastError(ERROR_BAD_EXE_FORMAT);
-        return NULL;
-    }
+	if (!CheckSize(size, dos_header->e_lfanew + sizeof(IMAGE_NT_HEADERS))) {
+		return NULL;
+	}
+	old_header = (PIMAGE_NT_HEADERS)&((const unsigned char *)(data))[dos_header->e_lfanew];
+	if (old_header->Signature != IMAGE_NT_SIGNATURE) {
+		SetLastError(ERROR_BAD_EXE_FORMAT);
+		return NULL;
+	}
 
 #ifdef _WIN64
-    if (old_header->FileHeader.Machine != IMAGE_FILE_MACHINE_AMD64) {
+	if (old_header->FileHeader.Machine != IMAGE_FILE_MACHINE_AMD64) {
 #else
-    if (old_header->FileHeader.Machine != IMAGE_FILE_MACHINE_I386) {
+	if (old_header->FileHeader.Machine != IMAGE_FILE_MACHINE_I386) {
 #endif
-        SetLastError(ERROR_BAD_EXE_FORMAT);
-        return NULL;
-    }
+		SetLastError(ERROR_BAD_EXE_FORMAT);
+		return NULL;
+	}
 
-    if (old_header->OptionalHeader.SectionAlignment & 1) {
-        // Only support section alignments that are a multiple of 2
-        SetLastError(ERROR_BAD_EXE_FORMAT);
-        return NULL;
-    }
+	if (old_header->OptionalHeader.SectionAlignment & 1) {
+		// Only support section alignments that are a multiple of 2
+		SetLastError(ERROR_BAD_EXE_FORMAT);
+		return NULL;
+	}
 
-    section = IMAGE_FIRST_SECTION(old_header);
-    optionalSectionSize = old_header->OptionalHeader.SectionAlignment;
-    for (i=0; i < old_header->FileHeader.NumberOfSections; i++, section++) {
-        size_t endOfSection;
-        if (section->SizeOfRawData == 0) {
-            // Section without data in the DLL
-            endOfSection = section->VirtualAddress + optionalSectionSize;
-        } else {
-            endOfSection = section->VirtualAddress + section->SizeOfRawData;
-        }
+	section = IMAGE_FIRST_SECTION(old_header);
+	optionalSectionSize = old_header->OptionalHeader.SectionAlignment;
+	for (i=0; i < old_header->FileHeader.NumberOfSections; i++, section++) {
+		size_t endOfSection;
+		if (section->SizeOfRawData == 0) {
+			// Section without data in the DLL
+			endOfSection = section->VirtualAddress + optionalSectionSize;
+		} else {
+			endOfSection = section->VirtualAddress + section->SizeOfRawData;
+		}
 
-        if (endOfSection > lastSectionEnd) {
-            lastSectionEnd = endOfSection;
-        }
-    }
+		if (endOfSection > lastSectionEnd) {
+			lastSectionEnd = endOfSection;
+		}
+	}
 
-    int dwPageSize;
+	int dwPageSize;
 
-    #ifdef OnWin
-        GetNativeSystemInfo(&sysInfo);
-        dwPageSize = sysInfo.dwPageSize;
-    #else
-        dwPageSize = 4096;  // TODO
-    #endif
+	#ifdef OnWin
+		GetNativeSystemInfo(&sysInfo);
+		dwPageSize = sysInfo.dwPageSize;
+	#else
+		dwPageSize = 4096;  // TODO
+	#endif
 
-    alignedImageSize = ALIGN_VALUE_UP(old_header->OptionalHeader.SizeOfImage, dwPageSize);
-    if (alignedImageSize != ALIGN_VALUE_UP(lastSectionEnd, dwPageSize)) {
-        SetLastError(ERROR_BAD_EXE_FORMAT);
-        return NULL;
-    }
-    // alignedImageSize=0;
+	alignedImageSize = ALIGN_VALUE_UP(old_header->OptionalHeader.SizeOfImage, dwPageSize);
+	if (alignedImageSize != ALIGN_VALUE_UP(lastSectionEnd, dwPageSize)) {
+		SetLastError(ERROR_BAD_EXE_FORMAT);
+		return NULL;
+	}
+	// alignedImageSize=0;
 
-    // reserve memory for image of library
-    // XXX: is it correct to commit the complete memory region at once?
-    //      calling DllEntry raises an exception if we don't...
-    code = (unsigned char *)allocMemory((LPVOID)(old_header->OptionalHeader.ImageBase),
-        alignedImageSize,
-        MEM_RESERVE | MEM_COMMIT,
-        PAGE_READWRITE,
-        userdata);
+	// reserve memory for image of library
+	// XXX: is it correct to commit the complete memory region at once?
+	//      calling DllEntry raises an exception if we don't...
+	code = (unsigned char *)allocMemory((LPVOID)(old_header->OptionalHeader.ImageBase),
+		alignedImageSize,
+		MEM_RESERVE | MEM_COMMIT,
+		PAGE_READWRITE,
+		userdata);
 
-    if (code == NULL) {
-        // try to allocate memory at arbitrary position
-        code = (unsigned char *)allocMemory(NULL,
-            alignedImageSize,
-            MEM_RESERVE | MEM_COMMIT,
-            PAGE_READWRITE,
-            userdata);
-        if (code == NULL) {
-            SetLastError(ERROR_OUTOFMEMORY);
-            return NULL;
-        }
-    }
+	if (code == NULL) {
+		// try to allocate memory at arbitrary position
+		code = (unsigned char *)allocMemory(NULL,
+			alignedImageSize,
+			MEM_RESERVE | MEM_COMMIT,
+			PAGE_READWRITE,
+			userdata);
+		if (code == NULL) {
+			SetLastError(ERROR_OUTOFMEMORY);
+			return NULL;
+		}
+	}
 
-    #ifdef OnWin
-    result = (PMEMORYMODULE)HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(MEMORYMODULE));
-    #else
-        result = (PMEMORYMODULE)calloc(1, sizeof(MEMORYMODULE));
-    #endif
+	#ifdef OnWin
+	result = (PMEMORYMODULE)HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(MEMORYMODULE));
+	#else
+		result = (PMEMORYMODULE)calloc(1, sizeof(MEMORYMODULE));
+	#endif
 
-    if (result == NULL) {
-        freeMemory(code, 0, MEM_RELEASE, userdata);
-        SetLastError(ERROR_OUTOFMEMORY);
-        return NULL;
-    }
+	if (result == NULL) {
+		freeMemory(code, 0, MEM_RELEASE, userdata);
+		SetLastError(ERROR_OUTOFMEMORY);
+		return NULL;
+	}
 
-    result->codeBase = code;
-    result->isDLL = (old_header->FileHeader.Characteristics & IMAGE_FILE_DLL) != 0;
-    result->alloc = allocMemory;
-    result->free = freeMemory;
-    result->loadLibrary = loadLibrary;
-    result->getProcAddress = getProcAddress;
-    result->freeLibrary = freeLibrary;
-    result->userdata = userdata;
-    result->pageSize = dwPageSize;
+	result->codeBase = code;
+	result->isDLL = (old_header->FileHeader.Characteristics & IMAGE_FILE_DLL) != 0;
+	result->alloc = allocMemory;
+	result->free = freeMemory;
+	result->loadLibrary = loadLibrary;
+	result->getProcAddress = getProcAddress;
+	result->freeLibrary = freeLibrary;
+	result->userdata = userdata;
+	result->pageSize = dwPageSize;
 
-    if (!CheckSize(size, old_header->OptionalHeader.SizeOfHeaders)) {
-        goto error;
-    }
+	if (!CheckSize(size, old_header->OptionalHeader.SizeOfHeaders)) {
+		goto error;
+	}
 
-    // commit memory for headers
-    headers = (unsigned char *)allocMemory(code,
-        old_header->OptionalHeader.SizeOfHeaders,
-        MEM_COMMIT,
-        PAGE_READWRITE,
-        userdata);
+	// commit memory for headers
+	headers = (unsigned char *)allocMemory(code,
+		old_header->OptionalHeader.SizeOfHeaders,
+		MEM_COMMIT,
+		PAGE_READWRITE,
+		userdata);
 
-    // copy PE header to code
-    memcpy(headers, dos_header, old_header->OptionalHeader.SizeOfHeaders);
-    result->headers = (PIMAGE_NT_HEADERS)&((const unsigned char *)(headers))[dos_header->e_lfanew];
+	// copy PE header to code
+	memcpy(headers, dos_header, old_header->OptionalHeader.SizeOfHeaders);
+	result->headers = (PIMAGE_NT_HEADERS)&((const unsigned char *)(headers))[dos_header->e_lfanew];
 
-    // update position
-    result->headers->OptionalHeader.ImageBase = (uintptr_t)code;
+	// update position
+	result->headers->OptionalHeader.ImageBase = (uintptr_t)code;
 
-    // copy sections from DLL file block to new memory location
-    if (!CopySections((const unsigned char *) data, size, old_header, result)) {
-        goto error;
-    }
+	// copy sections from DLL file block to new memory location
+	if (!CopySections((const unsigned char *) data, size, old_header, result)) {
+		goto error;
+	}
 
-    // adjust base address of imported data
-    locationDelta = (ptrdiff_t)(result->headers->OptionalHeader.ImageBase - old_header->OptionalHeader.ImageBase);
-    if (locationDelta != 0) {
-        result->isRelocated = PerformBaseRelocation(result, locationDelta);
-    } else {
-        result->isRelocated = TRUE;
-    }
+	// adjust base address of imported data
+	locationDelta = (ptrdiff_t)(result->headers->OptionalHeader.ImageBase - old_header->OptionalHeader.ImageBase);
+	if (locationDelta != 0) {
+		result->isRelocated = PerformBaseRelocation(result, locationDelta);
+	} else {
+		result->isRelocated = TRUE;
+	}
 
-    // load required dlls and adjust function table of imports
-    if (!BuildImportTable(result)) {
-        goto error;
-    }
+	// load required dlls and adjust function table of imports
+	if (!BuildImportTable(result)) {
+		goto error;
+	}
 
-    // mark memory pages depending on section headers and release
-    // sections that are marked as "discardable"
-    if (!FinalizeSections(result)) {
-        goto error;
-    }
+	// mark memory pages depending on section headers and release
+	// sections that are marked as "discardable"
+	if (!FinalizeSections(result)) {
+		goto error;
+	}
 
 
 #ifndef CustomLoader
-    // Todo According to Microsoft, Thread Local Storage (TLS) is a mechanism that allows Microsoft Windows to define data objects that are not automatic (stack) variables,
-    // yet are "local to each individual thread that runs the code. Thus, each thread can maintain a different value for a variable declared by using TLS."
-    // TLS callbacks are executed BEFORE the main loading
-    if (!ExecuteTLS(result))
-        goto error;
+	// Todo According to Microsoft, Thread Local Storage (TLS) is a mechanism that allows Microsoft Windows to define data objects that are not automatic (stack) variables,
+	// yet are "local to each individual thread that runs the code. Thus, each thread can maintain a different value for a variable declared by using TLS."
+	// TLS callbacks are executed BEFORE the main loading
+	if (!ExecuteTLS(result))
+		goto error;
 #endif
 
-    // get entry point of loaded library
-    if (result->headers->OptionalHeader.AddressOfEntryPoint != 0) {
-        if (result->isDLL) {
-                // 
+	// get entry point of loaded library
+	if (result->headers->OptionalHeader.AddressOfEntryPoint != 0) {
+		if (result->isDLL) {
+				// 
 			_EXE_LOADER_DEBUG(0, "Format de fichier : Librairie", "File format : Library");
-            DllEntryProc DllEntry = (DllEntryProc)(LPVOID)(code + result->headers->OptionalHeader.AddressOfEntryPoint);
-            if (DllEntry == 0) {
-                return NULL;
-            }
-            /* TODO: notify library about attaching to process
-            BOOL successfull = (*DllEntry)((HINSTANCE)code, DLL_PROCESS_ATTACH, 0);
-            if (!successfull) {
-                SetLastError(ERROR_DLL_INIT_FAILED);
-                goto error;
-            }
-            */
-            result->initialized = TRUE;
-        } else {
+			DllEntryProc DllEntry = (DllEntryProc)(LPVOID)(code + result->headers->OptionalHeader.AddressOfEntryPoint);
+			if (DllEntry == 0) {
+				return NULL;
+			}
+			/* TODO: notify library about attaching to process
+			BOOL successfull = (*DllEntry)((HINSTANCE)code, DLL_PROCESS_ATTACH, 0);
+			if (!successfull) {
+				SetLastError(ERROR_DLL_INIT_FAILED);
+				goto error;
+			}
+			*/
+			result->initialized = TRUE;
+		} else {
 			_EXE_LOADER_DEBUG(0, "Format de fichier : Executable Windows", "File format : Windows execuable");
-            result->exeEntry = (ExeEntryProc)(LPVOID)(code + result->headers->OptionalHeader.AddressOfEntryPoint);
+			result->exeEntry = (ExeEntryProc)(LPVOID)(code + result->headers->OptionalHeader.AddressOfEntryPoint);
 			// fprintf(stdout, "Address 0x%08x\n", result->exeEntry);
-        }
-    } else {
-        result->exeEntry = NULL;
-    }
+		}
+	} else {
+		result->exeEntry = NULL;
+	}
 
-    return (HMEMORYMODULE)result;
+	return (HMEMORYMODULE)result;
 
 error:
-    // cleanup
-    MemoryFreeLibrary(result);
-    return NULL;
+	// cleanup
+	MemoryFreeLibrary(result);
+	return NULL;
 }
 
 FARPROC MemoryModule::MemoryGetProcAddress(HMEMORYMODULE module, LPCSTR name) {
-    unsigned char *codeBase = ((PMEMORYMODULE)module)->codeBase;
-    DWORD idx = 0;
-    PIMAGE_EXPORT_DIRECTORY exports;
-    PIMAGE_DATA_DIRECTORY directory = GET_HEADER_DICTIONARY((PMEMORYMODULE)module, IMAGE_DIRECTORY_ENTRY_EXPORT);
-    if (directory->Size == 0) {
-        // no export table found
-        SetLastError(ERROR_PROC_NOT_FOUND);
-        return NULL;
-    }
+	unsigned char *codeBase = ((PMEMORYMODULE)module)->codeBase;
+	DWORD idx = 0;
+	PIMAGE_EXPORT_DIRECTORY exports;
+	PIMAGE_DATA_DIRECTORY directory = GET_HEADER_DICTIONARY((PMEMORYMODULE)module, IMAGE_DIRECTORY_ENTRY_EXPORT);
+	if (directory->Size == 0) {
+		// no export table found
+		SetLastError(ERROR_PROC_NOT_FOUND);
+		return NULL;
+	}
 
-    exports = (PIMAGE_EXPORT_DIRECTORY) (codeBase + directory->VirtualAddress);
-    if (exports->NumberOfNames == 0 || exports->NumberOfFunctions == 0) {
-        // DLL doesn't export anything
-        SetLastError(ERROR_PROC_NOT_FOUND);
-        return NULL;
-    }
+	exports = (PIMAGE_EXPORT_DIRECTORY) (codeBase + directory->VirtualAddress);
+	if (exports->NumberOfNames == 0 || exports->NumberOfFunctions == 0) {
+		// DLL doesn't export anything
+		SetLastError(ERROR_PROC_NOT_FOUND);
+		return NULL;
+	}
 
-    if (HIWORD(name) == 0) {
-        // load function by ordinal value
-        if (LOWORD(name) < exports->Base) {
-            SetLastError(ERROR_PROC_NOT_FOUND);
-            return NULL;
-        }
+	if (HIWORD(name) == 0) {
+		// load function by ordinal value
+		if (LOWORD(name) < exports->Base) {
+			SetLastError(ERROR_PROC_NOT_FOUND);
+			return NULL;
+		}
 
-        idx = LOWORD(name) - exports->Base;
-    } else {
-        // search function name in list of exported names
-        DWORD i;
-        DWORD *nameRef = (DWORD *) (codeBase + exports->AddressOfNames);
-        WORD *ordinal = (WORD *) (codeBase + exports->AddressOfNameOrdinals);
-        BOOL found = FALSE;
-        for (i=0; i < exports->NumberOfNames; i++, nameRef++, ordinal++) {
-            if (strcmp(name, (const char *) (codeBase + (*nameRef))) == 0) {
-                idx = *ordinal;
-                found = TRUE;
-                break;
-            }
-        }
+		idx = LOWORD(name) - exports->Base;
+	} else {
+		// search function name in list of exported names
+		DWORD i;
+		DWORD *nameRef = (DWORD *) (codeBase + exports->AddressOfNames);
+		WORD *ordinal = (WORD *) (codeBase + exports->AddressOfNameOrdinals);
+		BOOL found = FALSE;
+		for (i=0; i < exports->NumberOfNames; i++, nameRef++, ordinal++) {
+			if (strcmp(name, (const char *) (codeBase + (*nameRef))) == 0) {
+				idx = *ordinal;
+				found = TRUE;
+				break;
+			}
+		}
 
-        if (!found) {
-            // exported symbol not found
-            SetLastError(ERROR_PROC_NOT_FOUND);
-            return NULL;
-        }
-    }
+		if (!found) {
+			// exported symbol not found
+			SetLastError(ERROR_PROC_NOT_FOUND);
+			return NULL;
+		}
+	}
 
-    if (idx > exports->NumberOfFunctions) {
-        // name <-> ordinal number don't match
-        SetLastError(ERROR_PROC_NOT_FOUND);
-        return NULL;
-    }
+	if (idx > exports->NumberOfFunctions) {
+		// name <-> ordinal number don't match
+		SetLastError(ERROR_PROC_NOT_FOUND);
+		return NULL;
+	}
 
-    // AddressOfFunctions contains the RVAs to the "real" functions
-    return (FARPROC)(LPVOID)(codeBase + (*(DWORD *) (codeBase + exports->AddressOfFunctions + (idx*4))));
+	// AddressOfFunctions contains the RVAs to the "real" functions
+	return (FARPROC)(LPVOID)(codeBase + (*(DWORD *) (codeBase + exports->AddressOfFunctions + (idx*4))));
 }
 
 void MemoryModule::MemoryFreeLibrary(HMEMORYMODULE mod) {
-    PMEMORYMODULE module = (PMEMORYMODULE)mod;
+	PMEMORYMODULE module = (PMEMORYMODULE)mod;
 
-    if (module == NULL) {
-        return;
-    }
-    if (module->initialized) {
-        // notify library about detaching from process
-        DllEntryProc DllEntry = (DllEntryProc)(LPVOID)(module->codeBase + module->headers->OptionalHeader.AddressOfEntryPoint);
-        (*DllEntry)((HINSTANCE)module->codeBase, DLL_PROCESS_DETACH, 0);
-    }
+	if (module == NULL) {
+		return;
+	}
+	if (module->initialized) {
+		// notify library about detaching from process
+		DllEntryProc DllEntry = (DllEntryProc)(LPVOID)(module->codeBase + module->headers->OptionalHeader.AddressOfEntryPoint);
+		(*DllEntry)((HINSTANCE)module->codeBase, DLL_PROCESS_DETACH, 0);
+	}
 
-    if (module->modules != NULL) {
-        // free previously opened libraries
-        int i;
-        for (i=0; i < module->numModules; i++) {
-            if (module->modules[i] != NULL) {
-                module->freeLibrary(module->modules[i], module->userdata);
-            }
-        }
+	if (module->modules != NULL) {
+		// free previously opened libraries
+		int i;
+		for (i=0; i < module->numModules; i++) {
+			if (module->modules[i] != NULL) {
+				module->freeLibrary(module->modules[i], module->userdata);
+			}
+		}
 
-        free(module->modules);
-    }
+		free(module->modules);
+	}
 
-    if (module->codeBase != NULL) {
-        // release memory of library
-        module->free(module->codeBase, 0, MEM_RELEASE, module->userdata);
-    }
+	if (module->codeBase != NULL) {
+		// release memory of library
+		module->free(module->codeBase, 0, MEM_RELEASE, module->userdata);
+	}
 
-    #ifdef OnWin
-        HeapFree(GetProcessHeap(), 0, module);
-    #else
-        free(module);
-    #endif
+	#ifdef OnWin
+		HeapFree(GetProcessHeap(), 0, module);
+	#else
+		free(module);
+	#endif
 }
 
 int MemoryModule::MemoryCallEntryPoint(HMEMORYMODULE mod) {
-    PMEMORYMODULE module = (PMEMORYMODULE)mod;
+	PMEMORYMODULE module = (PMEMORYMODULE)mod;
 	
 	fprintf(stdout, "Adresse 0x%08x\n", module->exeEntry);
 
-    if (module == NULL || module->isDLL || module->exeEntry == NULL || !module->isRelocated) {
+	if (module == NULL || module->isDLL || module->exeEntry == NULL || !module->isRelocated) {
 		fprintf(stdout, "ARF.....\n");
-        return -1;
-    }
+		return -1;
+	}
 
 	fprintf(stdout, "EXECUFFIIOOONn..... 0x%08x\n", module->exeEntry);
-    return module->exeEntry();
+	return module->exeEntry();
 }
 
 #define DEFAULT_LANGUAGE        MAKELANGID(LANG_NEUTRAL, SUBLANG_NEUTRAL)
 
 HMEMORYRSRC MemoryModule::MemoryFindResource(HMEMORYMODULE module, LPCTSTR name, LPCTSTR type) {
-    return MemoryFindResourceEx(module, name, type, DEFAULT_LANGUAGE);
+	return MemoryFindResourceEx(module, name, type, DEFAULT_LANGUAGE);
 }
 
 
 static PIMAGE_RESOURCE_DIRECTORY_ENTRY _MemorySearchResourceEntry(void *root, PIMAGE_RESOURCE_DIRECTORY resources,
 		LPCTSTR key) {
-    /* TODO: MemorySearchResourceEntry
+	/* TODO: MemorySearchResourceEntry
 
-    PIMAGE_RESOURCE_DIRECTORY_ENTRY entries = (PIMAGE_RESOURCE_DIRECTORY_ENTRY) (resources + 1);
-    PIMAGE_RESOURCE_DIRECTORY_ENTRY result = NULL;
-    DWORD start;
-    DWORD end;
-    DWORD middle;
+	PIMAGE_RESOURCE_DIRECTORY_ENTRY entries = (PIMAGE_RESOURCE_DIRECTORY_ENTRY) (resources + 1);
+	PIMAGE_RESOURCE_DIRECTORY_ENTRY result = NULL;
+	DWORD start;
+	DWORD end;
+	DWORD middle;
 
-    if (!IS_INTRESOURCE(key) && key[0] == TEXT('#')) {
-        // special case: resource id given as string
-        TCHAR *endpos = NULL;
-        long int tmpkey = (WORD) strtol((TCHAR *) &key[1], &endpos, 10);
-        if (tmpkey <= 0xffff && strlen(endpos) == 0) {
-            key = MAKEINTRESOURCE(tmpkey);
-        }
-    }
+	if (!IS_INTRESOURCE(key) && key[0] == TEXT('#')) {
+		// special case: resource id given as string
+		TCHAR *endpos = NULL;
+		long int tmpkey = (WORD) strtol((TCHAR *) &key[1], &endpos, 10);
+		if (tmpkey <= 0xffff && strlen(endpos) == 0) {
+			key = MAKEINTRESOURCE(tmpkey);
+		}
+	}
 
-    // entries are stored as ordered list of named entries,
-    // followed by an ordered list of id entries - we can do
-    // a binary search to find faster...
-    if (IS_INTRESOURCE(key)) {
-        WORD check = (WORD) (uintptr_t) key;
-        start = resources->NumberOfNamedEntries;
-        end = start + resources->NumberOfIdEntries;
+	// entries are stored as ordered list of named entries,
+	// followed by an ordered list of id entries - we can do
+	// a binary search to find faster...
+	if (IS_INTRESOURCE(key)) {
+		WORD check = (WORD) (uintptr_t) key;
+		start = resources->NumberOfNamedEntries;
+		end = start + resources->NumberOfIdEntries;
 
-        while (end > start) {
-            WORD entryName;
-            middle = (start + end) >> 1;
-            entryName = (WORD) entries[middle].Name;
-            if (check < entryName) {
-                end = (end != middle ? middle : middle-1);
-            } else if (check > entryName) {
-                start = (start != middle ? middle : middle+1);
-            } else {
-                result = &entries[middle];
-                break;
-            }
-        }
-    } else {
-        CONST CHAR* searchKey;
-        size_t searchKeyLen = strlen(key);
+		while (end > start) {
+			WORD entryName;
+			middle = (start + end) >> 1;
+			entryName = (WORD) entries[middle].Name;
+			if (check < entryName) {
+				end = (end != middle ? middle : middle-1);
+			} else if (check > entryName) {
+				start = (start != middle ? middle : middle+1);
+			} else {
+				result = &entries[middle];
+				break;
+			}
+		}
+	} else {
+		CONST CHAR* searchKey;
+		size_t searchKeyLen = strlen(key);
 #if defined(UNICODE)
-        searchKey = key;
+		searchKey = key;
 #else
-        // Resource names are always stored using 16bit characters, need to
-        // convert string we search for.
+		// Resource names are always stored using 16bit characters, need to
+		// convert string we search for.
 #define MAX_LOCAL_KEY_LENGTH 2048
-        // In most cases resource names are short, so optimize for that by
-        // using a pre-allocated array.
-        wchar_t _searchKeySpace[MAX_LOCAL_KEY_LENGTH+1];
-        LPWSTR _searchKey;
-        if (searchKeyLen > MAX_LOCAL_KEY_LENGTH) {
-            size_t _searchKeySize = (searchKeyLen + 1) * sizeof(wchar_t);
-            _searchKey = (LPWSTR) malloc(_searchKeySize);
-            if (_searchKey == NULL) {
-                SetLastError(ERROR_OUTOFMEMORY);
-                return NULL;
-            }
-        } else {
-            _searchKey = &_searchKeySpace[0];
-        }
+		// In most cases resource names are short, so optimize for that by
+		// using a pre-allocated array.
+		wchar_t _searchKeySpace[MAX_LOCAL_KEY_LENGTH+1];
+		LPWSTR _searchKey;
+		if (searchKeyLen > MAX_LOCAL_KEY_LENGTH) {
+			size_t _searchKeySize = (searchKeyLen + 1) * sizeof(wchar_t);
+			_searchKey = (LPWSTR) malloc(_searchKeySize);
+			if (_searchKey == NULL) {
+				SetLastError(ERROR_OUTOFMEMORY);
+				return NULL;
+			}
+		} else {
+			_searchKey = &_searchKeySpace[0];
+		}
 
-        mbstowcs(_searchKey, key, searchKeyLen);
-        _searchKey[searchKeyLen] = 0;
-        searchKey = _searchKey;
+		mbstowcs(_searchKey, key, searchKeyLen);
+		_searchKey[searchKeyLen] = 0;
+		searchKey = _searchKey;
 #endif
-        start = 0;
-        end = resources->NumberOfNamedEntries;
-        while (end > start) {
-            int cmp;
-            PIMAGE_RESOURCE_DIR_STRING_U resourceString;
-            middle = (start + end) >> 1;
-            resourceString = (PIMAGE_RESOURCE_DIR_STRING_U) (((char *) root) + (entries[middle].Name & 0x7FFFFFFF));
-            cmp = strncmp(searchKey, resourceString->NameString, resourceString->Length);
-            if (cmp == 0) {
-                // Handle partial match
-                cmp = searchKeyLen - resourceString->Length;
-            }
-            if (cmp < 0) {
-                end = (middle != end ? middle : middle-1);
-            } else if (cmp > 0) {
-                start = (middle != start ? middle : middle+1);
-            } else {
-                result = &entries[middle];
-                break;
-            }
-        }
+		start = 0;
+		end = resources->NumberOfNamedEntries;
+		while (end > start) {
+			int cmp;
+			PIMAGE_RESOURCE_DIR_STRING_U resourceString;
+			middle = (start + end) >> 1;
+			resourceString = (PIMAGE_RESOURCE_DIR_STRING_U) (((char *) root) + (entries[middle].Name & 0x7FFFFFFF));
+			cmp = strncmp(searchKey, resourceString->NameString, resourceString->Length);
+			if (cmp == 0) {
+				// Handle partial match
+				cmp = searchKeyLen - resourceString->Length;
+			}
+			if (cmp < 0) {
+				end = (middle != end ? middle : middle-1);
+			} else if (cmp > 0) {
+				start = (middle != start ? middle : middle+1);
+			} else {
+				result = &entries[middle];
+				break;
+			}
+		}
 #if !defined(UNICODE)
-        if (searchKeyLen > MAX_LOCAL_KEY_LENGTH) {
-            free(_searchKey);
-        }
+		if (searchKeyLen > MAX_LOCAL_KEY_LENGTH) {
+			free(_searchKey);
+		}
 #undef MAX_LOCAL_KEY_LENGTH
 #endif
-    }
+	}
 
-    return result;
-    */
-    return 0;
+	return result;
+	*/
+	return 0;
 }
 
 HMEMORYRSRC MemoryModule::MemoryFindResourceEx(HMEMORYMODULE module, LPCTSTR name, LPCTSTR type, WORD language) {
-    /* TODO: MemoryFindResourceEx
-    unsigned char *codeBase = ((PMEMORYMODULE) module)->codeBase;
-    PIMAGE_DATA_DIRECTORY directory = GET_HEADER_DICTIONARY((PMEMORYMODULE) module, IMAGE_DIRECTORY_ENTRY_RESOURCE);
-    PIMAGE_RESOURCE_DIRECTORY rootResources;
-    PIMAGE_RESOURCE_DIRECTORY nameResources;
-    PIMAGE_RESOURCE_DIRECTORY typeResources;
-    PIMAGE_RESOURCE_DIRECTORY_ENTRY foundType;
-    PIMAGE_RESOURCE_DIRECTORY_ENTRY foundName;
-    PIMAGE_RESOURCE_DIRECTORY_ENTRY foundLanguage;
-    if (directory->Size == 0) {
-        // no resource table found
-        SetLastError(ERROR_RESOURCE_DATA_NOT_FOUND);
-        return NULL;
-    }
+	/* TODO: MemoryFindResourceEx
+	unsigned char *codeBase = ((PMEMORYMODULE) module)->codeBase;
+	PIMAGE_DATA_DIRECTORY directory = GET_HEADER_DICTIONARY((PMEMORYMODULE) module, IMAGE_DIRECTORY_ENTRY_RESOURCE);
+	PIMAGE_RESOURCE_DIRECTORY rootResources;
+	PIMAGE_RESOURCE_DIRECTORY nameResources;
+	PIMAGE_RESOURCE_DIRECTORY typeResources;
+	PIMAGE_RESOURCE_DIRECTORY_ENTRY foundType;
+	PIMAGE_RESOURCE_DIRECTORY_ENTRY foundName;
+	PIMAGE_RESOURCE_DIRECTORY_ENTRY foundLanguage;
+	if (directory->Size == 0) {
+		// no resource table found
+		SetLastError(ERROR_RESOURCE_DATA_NOT_FOUND);
+		return NULL;
+	}
 
-    if (language == DEFAULT_LANGUAGE) {
-        // use language from current thread
-        language = LANGIDFROMLCID(GetThreadLocale());
-    }
+	if (language == DEFAULT_LANGUAGE) {
+		// use language from current thread
+		language = LANGIDFROMLCID(GetThreadLocale());
+	}
 
-    // resources are stored as three-level tree
-    // - first node is the type
-    // - second node is the name
-    // - third node is the language
-    rootResources = (PIMAGE_RESOURCE_DIRECTORY) (codeBase + directory->VirtualAddress);
-    foundType = _MemorySearchResourceEntry(rootResources, rootResources, type);
-    if (foundType == NULL) {
-        SetLastError(ERROR_RESOURCE_TYPE_NOT_FOUND);
-        return NULL;
-    }
+	// resources are stored as three-level tree
+	// - first node is the type
+	// - second node is the name
+	// - third node is the language
+	rootResources = (PIMAGE_RESOURCE_DIRECTORY) (codeBase + directory->VirtualAddress);
+	foundType = _MemorySearchResourceEntry(rootResources, rootResources, type);
+	if (foundType == NULL) {
+		SetLastError(ERROR_RESOURCE_TYPE_NOT_FOUND);
+		return NULL;
+	}
 
-    typeResources = (PIMAGE_RESOURCE_DIRECTORY) (codeBase + directory->VirtualAddress + (foundType->OffsetToData & 0x7fffffff));
-    foundName = _MemorySearchResourceEntry(rootResources, typeResources, name);
-    if (foundName == NULL) {
-        SetLastError(ERROR_RESOURCE_NAME_NOT_FOUND);
-        return NULL;
-    }
+	typeResources = (PIMAGE_RESOURCE_DIRECTORY) (codeBase + directory->VirtualAddress + (foundType->OffsetToData & 0x7fffffff));
+	foundName = _MemorySearchResourceEntry(rootResources, typeResources, name);
+	if (foundName == NULL) {
+		SetLastError(ERROR_RESOURCE_NAME_NOT_FOUND);
+		return NULL;
+	}
 
-    nameResources = (PIMAGE_RESOURCE_DIRECTORY) (codeBase + directory->VirtualAddress + (foundName->OffsetToData & 0x7fffffff));
-    foundLanguage = _MemorySearchResourceEntry(rootResources, nameResources, (LPCTSTR) (uintptr_t) language);
-    if (foundLanguage == NULL) {
-        // requested language not found, use first available
-        if (nameResources->NumberOfIdEntries == 0) {
-            SetLastError(ERROR_RESOURCE_LANG_NOT_FOUND);
-            return NULL;
-        }
+	nameResources = (PIMAGE_RESOURCE_DIRECTORY) (codeBase + directory->VirtualAddress + (foundName->OffsetToData & 0x7fffffff));
+	foundLanguage = _MemorySearchResourceEntry(rootResources, nameResources, (LPCTSTR) (uintptr_t) language);
+	if (foundLanguage == NULL) {
+		// requested language not found, use first available
+		if (nameResources->NumberOfIdEntries == 0) {
+			SetLastError(ERROR_RESOURCE_LANG_NOT_FOUND);
+			return NULL;
+		}
 
-        foundLanguage = (PIMAGE_RESOURCE_DIRECTORY_ENTRY) (nameResources + 1);
-    }
+		foundLanguage = (PIMAGE_RESOURCE_DIRECTORY_ENTRY) (nameResources + 1);
+	}
 
-    return (codeBase + directory->VirtualAddress + (foundLanguage->OffsetToData & 0x7fffffff));
-    */
-    return 0;
+	return (codeBase + directory->VirtualAddress + (foundLanguage->OffsetToData & 0x7fffffff));
+	*/
+	return 0;
 }
 
 DWORD MemoryModule::MemorySizeofResource(HMEMORYMODULE module, HMEMORYRSRC resource) {
-    PIMAGE_RESOURCE_DATA_ENTRY entry;
-    UNREFERENCED_PARAMETER(module);
-    entry = (PIMAGE_RESOURCE_DATA_ENTRY) resource;
-    if (entry == NULL) {
-        return 0;
-    }
+	PIMAGE_RESOURCE_DATA_ENTRY entry;
+	UNREFERENCED_PARAMETER(module);
+	entry = (PIMAGE_RESOURCE_DATA_ENTRY) resource;
+	if (entry == NULL) {
+		return 0;
+	}
 
-    return entry->Size;
+	return entry->Size;
 }
 
 LPVOID MemoryModule::MemoryLoadResource(HMEMORYMODULE module, HMEMORYRSRC resource) {
-    unsigned char *codeBase = ((PMEMORYMODULE) module)->codeBase;
-    PIMAGE_RESOURCE_DATA_ENTRY entry = (PIMAGE_RESOURCE_DATA_ENTRY) resource;
-    if (entry == NULL) {
-        return NULL;
-    }
+	unsigned char *codeBase = ((PMEMORYMODULE) module)->codeBase;
+	PIMAGE_RESOURCE_DATA_ENTRY entry = (PIMAGE_RESOURCE_DATA_ENTRY) resource;
+	if (entry == NULL) {
+		return NULL;
+	}
 
-    return codeBase + entry->OffsetToData;
+	return codeBase + entry->OffsetToData;
 }
 
 int MemoryModule::MemoryLoadString(HMEMORYMODULE module, UINT id, LPTSTR buffer, int maxsize) {
-    return MemoryLoadStringEx(module, id, buffer, maxsize, DEFAULT_LANGUAGE);
+	return MemoryLoadStringEx(module, id, buffer, maxsize, DEFAULT_LANGUAGE);
 }
 
 int MemoryModule::MemoryLoadStringEx(HMEMORYMODULE module, UINT id, LPTSTR buffer, int maxsize, WORD language) {
-    /* TODO: MemoryLoadStringEx
-    HMEMORYRSRC resource;
-    PIMAGE_RESOURCE_DIR_STRING_U data;
-    DWORD size;
-    if (maxsize == 0) {
-        return 0;
-    }
+	/* TODO: MemoryLoadStringEx
+	HMEMORYRSRC resource;
+	PIMAGE_RESOURCE_DIR_STRING_U data;
+	DWORD size;
+	if (maxsize == 0) {
+		return 0;
+	}
 
-    resource = MemoryFindResourceEx(module, MAKEINTRESOURCE((id >> 4) + 1), RT_STRING, language);
-    if (resource == NULL) {
-        buffer[0] = 0;
-        return 0;
-    }
+	resource = MemoryFindResourceEx(module, MAKEINTRESOURCE((id >> 4) + 1), RT_STRING, language);
+	if (resource == NULL) {
+		buffer[0] = 0;
+		return 0;
+	}
 
-    data = (PIMAGE_RESOURCE_DIR_STRING_U) MemoryLoadResource(module, resource);
-    id = id & 0x0f;
-    while (id--) {
-        data = (PIMAGE_RESOURCE_DIR_STRING_U) (((char *) data) + (data->Length + 1) * sizeof(WCHAR));
-    }
-    if (data->Length == 0) {
-        SetLastError(ERROR_RESOURCE_NAME_NOT_FOUND);
-        buffer[0] = 0;
-        return 0;
-    }
+	data = (PIMAGE_RESOURCE_DIR_STRING_U) MemoryLoadResource(module, resource);
+	id = id & 0x0f;
+	while (id--) {
+		data = (PIMAGE_RESOURCE_DIR_STRING_U) (((char *) data) + (data->Length + 1) * sizeof(WCHAR));
+	}
+	if (data->Length == 0) {
+		SetLastError(ERROR_RESOURCE_NAME_NOT_FOUND);
+		buffer[0] = 0;
+		return 0;
+	}
 
-    size = data->Length;
-    if (size >= (DWORD) maxsize) {
-        size = maxsize;
-    } else {
-        buffer[size] = 0;
-    }
+	size = data->Length;
+	if (size >= (DWORD) maxsize) {
+		size = maxsize;
+	} else {
+		buffer[size] = 0;
+	}
 #if defined(UNICODE)
-    wcsncpy(buffer, data->NameString, size);
+	wcsncpy(buffer, data->NameString, size);
 #else
-    wcstombs(buffer, data->NameString, size);
+	wcstombs(buffer, data->NameString, size);
 #endif
-    return size;
-    */
-    return 0;
+	return size;
+	*/
+	return 0;
 }


### PR DESCRIPTION
More PR to come (slowly refactoring code)

# summary of changes

## GNU/Linux 
* change echo to printf in `build/build.sh`: `echo -e` isn't POSIX (bdd8bb6)

## Fix 
* remove `using namespace std; `: it's considered as a bad practice and can introduce some ambiguity in future (7032117)
* f wasn't closed in fExeCpcDosLoadFile (119bd00)

## Readability / Coding Style
* move include on top of file: improve code readability (af61d7b)
* convert tabs to space and remove useless space and blank line (92abae4 / 67e36ea / 82ec4ac) 
* move define, prototype, typedef from ExeLoader.cpp to ExeLoader.h (b3b9a0f)
* Remove useless comment (eg function) (1f5c402)
* move fStartExeLoader and main at end of file (fe6aa5d)
